### PR TITLE
point to failed assertion instead of to luassert files

### DIFF
--- a/src/assert.lua
+++ b/src/assert.lua
@@ -9,9 +9,9 @@ local __assertion_meta = {
     if data_type == "boolean" then
       if val ~= state.mod then
         if state.mod then
-          error(s(self.positive_message, {...}) or "assertion failed!")
+          error(s(self.positive_message, {...}) or "assertion failed!", 2)
         else
-          error(s(self.negative_message, {...}) or "assertion failed!")
+          error(s(self.negative_message, {...}) or "assertion failed!", 2)
         end
       else
         return state
@@ -73,7 +73,7 @@ local __meta = {
 
   __call = function(self, bool, message)
     if not bool then
-      error(message or "assertion failed!")
+      error(message or "assertion failed!", 2)
     end
     return bool
   end,


### PR DESCRIPTION
If an assertion fails the error is now given 1 level up, so instead of pointing to 'luassert/assert.lua' (line 12 or 76). It will now point to the exact line of the assert command that failed in the testfile.

Before:
Failure: ...pbox\Lua projects\lua_cliargs\specs\cliargs_spec.lua @ 43
tests the private split() function
C:\Users\Public\Lua\5.1\lua\luassert\assert.lua:12: Expected objects to be the same.

After:
Failure: ...pbox\Lua projects\lua_cliargs\specs\cliargs_spec.lua @ 43
tests the private split() function
...pbox\Lua projects\lua_cliargs\specs\cliargs_spec.lua:61: Expected objects to be the same.
