### PR TITLE
Fix table comparisons

### DIFF
--- a/src/util.lua
+++ b/src/util.lua
@@ -5,10 +5,15 @@ function util.deepcompare(t1,t2,ignore_mt)
   if ty1 ~= ty2 then return false end
   -- non-table types can be directly compared
   if ty1 ~= 'table' and ty2 ~= 'table' then return t1 == t2 end
-  -- as well as tables which have the metamethod __eq
   local mt1 = getmetatable(t1)
   local mt2 = getmetatable(t2)
-  if not ignore_mt and mt1 and mt1 == mt2 and mt1.__eq then return t1 == t2 end
+  -- would equality be determined by metatable __eq?
+  if mt1 and mt1 == mt2 and mt1.__eq then
+    -- then use that unless asked not to
+    if not ignore_mt then return t1 == t2 end
+  else -- we can skip the deep comparison below if t1 and t2 share identity
+    if t1 == t2 then return true end
+  end
   for k1,v1 in pairs(t1) do
     local v2 = t2[k1]
     if v2 == nil or not util.deepcompare(v1,v2) then return false end


### PR DESCRIPTION
This PR contains two commits that do the following:
- Fix check for determining whether a table's metatable __eq would be used for comparison.

Previously the check didn't take into account whether the two objects metatables were the same.
- Use identity check for tables when possible

Less work, and also makes it usable for the cases when tables are equal identity-wise and contain LuaJIT cdata values.
