### PR TITLE
Remove self argument for spy.new

### DIFF
--- a/src/mock.lua
+++ b/src/mock.lua
@@ -12,7 +12,7 @@ local function mock(object, dostub, func, self, key)
     if dostub then
       return stub(self, key, func)
     elseif self==nil then
-      return spy:new(object)
+      return spy.new(object)
     else
       return spy.on(self, key)
     end

--- a/src/spy.lua
+++ b/src/spy.lua
@@ -3,7 +3,7 @@ local assert = require('luassert.assert')
 local util = require('luassert.util')
 local spy   -- must make local before defining table, because table contents refers to the table (recursion)
 spy = {
-  new = function(self, callback)
+  new = function(callback)
     return setmetatable(
     {
       calls = {},
@@ -37,7 +37,7 @@ spy = {
   end,
 
   on = function(target_table, target_key)
-    target_table[target_key] = spy:new(target_table[target_key])
+    target_table[target_key] = spy.new(target_table[target_key])
     return target_table[target_key]
   end
 }
@@ -66,7 +66,7 @@ local function called(state, arguments)
     return result
   elseif state.payload and type(state.payload) == "function" then
     error("When calling 'spy(aspy)', 'aspy' must not be the original function, but the spy function replacing the original")
-  else  
+  else
     error("'called_with' must be chained after 'spy(aspy)'")
   end
 end

--- a/src/stub.lua
+++ b/src/stub.lua
@@ -2,6 +2,6 @@
 local spy = require 'luassert.spy'
 
 return function(self, key, func)
-  self[key] = spy:new(func)
+  self[key] = spy.new(func)
   return self[key]
 end


### PR DESCRIPTION
It's neither needed nor used , and not consistent with spy.on either. What it would
be used for, accessing its own table, is already handled by a local
forward declaration.

Use of the spy.new parameters is undocumented as far as I can see, with the busted documentation only containing one usage which is already in the form 

``` lua
spy.new()
```

Still, it means that any outside code calling it as spy:new will have to be updated,
