### PR TITLE
2 minor updates

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -240,6 +240,19 @@ describe("Test Assertions", function()
     assert.returned_arguments(2, fn3())
     assert.returned_arguments(3, fn4())
   end)
+
+  it("checks has_error to accept only callable arguments", function()
+    local t_ok = setmetatable( {}, { __call = function() end } )
+    local t_nok = setmetatable( {}, { __call = function() error("some error") end } )
+    local f_ok = function() end
+    local f_nok = function() error("some error") end
+    
+    assert.has_error(f_nok)
+    assert.has_no_error(f_ok)
+    assert.has_error(t_nok)
+    assert.has_no_error(t_ok)
+  end)
+
 end)
 
 

--- a/spec/stub_spec.lua
+++ b/spec/stub_spec.lua
@@ -12,15 +12,15 @@ describe("Tests dealing with stubs", function()
     stub(test, "key")
 
     test.key("derp")
-    assert.spy(test.key).was.called_with("derp")
-    assert.errors(function() assert.spy(test.key).was.called_with("herp") end)
+    assert.stub(test.key).was.called_with("derp")
+    assert.errors(function() assert.stub(test.key).was.called_with("herp") end)
   end)
 
   it("checks to see if stub keeps track of number of calls", function()
      stub(test, "key")
      test.key()
      test.key("test")
-     assert.spy(test.key).was.called(2)
+     assert.stub(test.key).was.called(2)
   end)
 
   it("checks called() and called_with() assertions", function()
@@ -28,12 +28,12 @@ describe("Tests dealing with stubs", function()
 
     s(1, 2, 3)
     s("a", "b", "c")
-    assert.spy(s).was.called()
-    assert.spy(s).was.called(2) -- twice!
-    assert.spy(s).was_not.called(3)
-    assert.spy(s).was_not.called_with({1, 2, 3}) -- mind the accolades
-    assert.spy(s).was.called_with(1, 2, 3)
-    assert.has_error(function() assert.spy(s).was.called_with(5, 6) end)
+    assert.stub(s).was.called()
+    assert.stub(s).was.called(2) -- twice!
+    assert.stub(s).was_not.called(3)
+    assert.stub(s).was_not.called_with({1, 2, 3}) -- mind the accolades
+    assert.stub(s).was.called_with(1, 2, 3)
+    assert.has_error(function() assert.stub(s).was.called_with(5, 6) end)
   end)
 
   it("checks stub to fail when spying on non-callable elements", function()
@@ -59,12 +59,12 @@ describe("Tests dealing with stubs", function()
      assert.is_table(s)
      s()
      s()
-     assert.spy(s).was.called(2)  
+     assert.stub(s).was.called(2)  
      assert.are.equal(calls, 0)   -- its a stub, so no calls
      local old_s = s
      s = s:revert()
      s()
-     assert.spy(old_s).was.called(2)  -- still two, stub was removed
+     assert.stub(old_s).was.called(2)  -- still two, stub was removed
      assert.are.equal(s, old)
      assert.are.equal(calls, 1)     -- restored, so now 1 call
   end)
@@ -75,7 +75,7 @@ describe("Tests dealing with stubs", function()
      assert.is_table(s)
      s()
      s()
-     assert.spy(s).was.called(2)  
+     assert.stub(s).was.called(2)  
      local old_s = s
      s = s:revert()
      assert.is_nil(s)
@@ -86,7 +86,7 @@ describe("Tests dealing with stubs", function()
      assert.is_table(s)
      s()
      s()
-     assert.spy(s).was.called(2)  
+     assert.stub(s).was.called(2)  
      local old_s = s
      s = s:revert()
      assert.is_nil(s)

--- a/src/assertions.lua
+++ b/src/assertions.lua
@@ -6,7 +6,7 @@
 -- returns; boolean; whether assertion passed
 
 local assert = require('luassert.assert')
-local util = require 'luassert.util'
+local util = require ('luassert.util')
 local s = require('say')
 
 local function unique(state, arguments)
@@ -78,7 +78,7 @@ local function has_error(state, arguments)
   local func = arguments[1]
   local err_expected = arguments[2]
   
-  assert(type(func) == "function", s("assertion.internal.badargtype", { "error", "function", type(func) }))
+  assert(util.callable(func), s("assertion.internal.badargtype", { "error", "function, or callable object", type(func) }))
   local err_actual = nil
   --must swap error functions to get the actual error message
   local old_error = error

--- a/src/stub.lua
+++ b/src/stub.lua
@@ -33,6 +33,11 @@ function stub.is_stub(object)
   return spy.is_spy(object) and object.callback == stubfunc
 end
 
+local function set_stub(state)
+end
+
+assert:register("modifier", "stub", set_stub)
+
 return setmetatable( stub, {
     __call = function(self, ...)
       -- stub originally was a function only. Now that it is a module table


### PR DESCRIPTION
fix: error assertion now takes a callable argument, instead of only functions
add: stub assertion (same as spy)
