### PR TITLE
Remove unnecessary test from util.deepcompare

### DIFF
--- a/src/util.lua
+++ b/src/util.lua
@@ -4,7 +4,7 @@ function util.deepcompare(t1,t2,ignore_mt)
   local ty2 = type(t2)
   if ty1 ~= ty2 then return false end
   -- non-table types can be directly compared
-  if ty1 ~= 'table' and ty2 ~= 'table' then return t1 == t2 end
+  if ty1 ~= 'table' then return t1 == t2 end
   local mt1 = debug.getmetatable(t1)
   local mt2 = debug.getmetatable(t2)
   -- would equality be determined by metatable __eq?


### PR DESCRIPTION
The immediately preceding test has made sure that `ty1` and `ty2` are the
same.

As a result, if `ty1 ~= 'table'`, there's no need to test `ty2` for the same thing.

(I know that this is awfully minor, but in the process of comparing the `deepcompare`
functions of Penlight, Underscore and luassert, I noticed this and thought it might be
worth mentioning. This is how [Underscore does it](https://github.com/mirven/underscore.lua/blob/master/lib/underscore.lua#L335).)
