### PR TITLE
Added multiplatform CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,22 @@
-language: erlang
+language: c
 
 env:
-  - LUA=""
-  - LUA="luajit"
+  - LUA="Lua 5.1"
+  - LUA="Lua 5.2"
+  - LUA="LuaJIT 2.0"
+
+before_install:
+  - bash .travis_setup.sh
+
+install:
+  - sudo luarocks make
+  - sudo luarocks install busted
+
+script: busted spec
 
 branches:
   only:
     - master
-
-install:
-  - sudo apt-get install luajit
-  - sudo apt-get install luarocks
-  - sudo luarocks install luafilesystem
-  - git clone git://github.com/Olivine-Labs/say.git
-  - cd say
-  - sudo luarocks make
-  - cd ../
-  - git clone git://github.com/Olivine-Labs/luassert.git
-  - cd luassert
-  - sudo luarocks make
-  - cd ../
-  - git clone git://github.com/Olivine-Labs/busted.git
-  - cd busted
-  - sudo luarocks make
-  - cd ../
-
-script: "sudo luarocks make && busted spec"
 
 notifications:
   webhooks:

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -1,0 +1,31 @@
+# A script for setting up environment for travis-ci testing. 
+# Sets up Lua and Luarocks. 
+# LUA must be "Lua 5.1", "Lua 5.2" or "LuaJIT 2.0". 
+
+if [ "$LUA" == "LuaJIT 2.0" ]; then
+  curl http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
+  cd LuaJIT-2.0.2
+  make && sudo make install INSTALL_TSYMNAME=lua;
+else
+  if [ "$LUA" == "Lua 5.1" ]; then
+    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    cd lua-5.1.5;
+  elif [ "$LUA" == "Lua 5.2" ]; then
+    curl http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
+    cd lua-5.2.3;
+  fi
+  sudo make linux install;
+fi
+
+cd ..
+curl http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
+cd luarocks-2.1.2
+
+if [ "$LUA" == "LuaJIT 2.0" ]; then
+  ./configure --with-lua-include=/usr/local/include/luajit-2.0;
+else
+  ./configure;
+fi
+
+make && sudo make install
+cd ..


### PR DESCRIPTION
It was mentioned in comments [here](https://github.com/Olivine-Labs/luassert/pull/51) that it would be nice to set up Travis to run tests on several Lua versions. I added a small script for installing Lua and Luarocks and changed .travis.yml to run three times, for Lua 5.1.5, Lua 5.2.3 and LuaJIT 2.0.2. Tell me if something should be tweaked! 

[This is how it looks on travis-ci.org](https://travis-ci.org/mpeterv/luassert/builds/19987902)
