### PR TITLE
Fix assert.remove_formatter

### DIFF
--- a/src/state.lua
+++ b/src/state.lua
@@ -71,7 +71,7 @@ end
 state.remove_formatter = function(callback, s)
   s = s or current
   for i, v in ipairs(s.formatters) do
-    if v == fmtr then
+    if v == callback then
       table.remove(s.formatters, i)
       break
     end


### PR DESCRIPTION
Currently `assert:remove_formatter(formatter)` does not actually do anything because it compares existing formatters with an undefined variable instead of the argument.

Testcase:

``` bash
$ cat testcase_spec.lua
```

``` lua
local binstring = require("luassert.formatters.binarystring")

describe("Tests using a binary string formatter", function()

  setup(function()
    assert:add_formatter(binstring)
  end)

  teardown(function()
    assert:remove_formatter(binstring)
  end)

  it("tests a string comparison with binary formatting", function()
    local s1, s2 = "", ""
    for n = 65,88 do
      s1 = s1 .. string.char(n)
      s2 = string.char(n) .. s2
    end
    assert.are.same(s1, s2)

  end)

end)

describe("Tests not using a formatter", function()

  it("tests a string comparison without binary formatting", function()
    local s1, s2 = "", ""
    for n = 65,88 do
      s1 = s1 .. string.char(n)
      s2 = string.char(n) .. s2
    end
    assert.are.same(s1, s2)

  end)

end)
```

Before fix:

``` bash
$ busted testcase_spec.lua
```

```
●●
0 successes / 2 failures / 0 errors / 0 pending : 0.0 seconds

Failure → ./testcase_spec.lua @ 13
Tests using a binary string formatter tests a string comparison with binary formatting
./testcase_spec.lua:19: Expected objects to be the same. Passed in:
Binary string length; 24 bytes
58 57 56 55 54 53 52 51   50 4f 4e 4d 4c 4b 4a 49  XWVUTSRQ PONMLKJI
48 47 46 45 44 43 42 41                            HGFEDCBA         

Expected:
Binary string length; 24 bytes
41 42 43 44 45 46 47 48   49 4a 4b 4c 4d 4e 4f 50  ABCDEFGH IJKLMNOP
51 52 53 54 55 56 57 58                            QRSTUVWX         


Failure → ./testcase_spec.lua @ 27
Tests not using a formatter tests a string comparison without binary formatting
./testcase_spec.lua:33: Expected objects to be the same. Passed in:
Binary string length; 24 bytes
58 57 56 55 54 53 52 51   50 4f 4e 4d 4c 4b 4a 49  XWVUTSRQ PONMLKJI
48 47 46 45 44 43 42 41                            HGFEDCBA         

Expected:
Binary string length; 24 bytes
41 42 43 44 45 46 47 48   49 4a 4b 4c 4d 4e 4f 50  ABCDEFGH IJKLMNOP
51 52 53 54 55 56 57 58                            QRSTUVWX
```

After fix:

``` bash
$ busted testcase_spec.lua
```

```
●●
0 successes / 2 failures / 0 errors / 0 pending : 0.0 seconds

Failure → ./testcase_spec.lua @ 13
Tests using a binary string formatter tests a string comparison with binary formatting
./testcase_spec.lua:19: Expected objects to be the same. Passed in:
Binary string length; 24 bytes
58 57 56 55 54 53 52 51   50 4f 4e 4d 4c 4b 4a 49  XWVUTSRQ PONMLKJI
48 47 46 45 44 43 42 41                            HGFEDCBA         

Expected:
Binary string length; 24 bytes
41 42 43 44 45 46 47 48   49 4a 4b 4c 4d 4e 4f 50  ABCDEFGH IJKLMNOP
51 52 53 54 55 56 57 58                            QRSTUVWX         


Failure → ./testcase_spec.lua @ 27
Tests not using a formatter tests a string comparison without binary formatting
./testcase_spec.lua:33: Expected objects to be the same. Passed in:
(string) 'XWVUTSRQPONMLKJIHGFEDCBA'
Expected:
(string) 'ABCDEFGHIJKLMNOPQRSTUVWX'
```
