### PR TITLE
Make assert.has_error print the actual and expected errors on failure

### DIFF
--- a/src/assertions.lua
+++ b/src/assertions.lua
@@ -77,7 +77,7 @@ end
 local function has_error(state, arguments)
   local func = arguments[1]
   local err_expected = arguments[2]
-  
+
   assert(util.callable(func), s("assertion.internal.badargtype", { "error", "function, or callable object", type(func) }))
   local err_actual = nil
   --must swap error functions to get the actual error message
@@ -88,9 +88,9 @@ local function has_error(state, arguments)
   end
   local status = pcall(func)
   error = old_error
-  local val = not status and (err_expected == nil or same(state, {err_expected, err_actual, ["n"] = 2}))
-
-  return val
+  arguments[1] = err_actual
+  arguments[2] = err_expected
+  return not status and (err_expected == nil or same(state, {err_expected, err_actual, ["n"] = 2}))
 end
 
 local function is_true(state, arguments)

--- a/src/languages/en.lua
+++ b/src/languages/en.lua
@@ -11,8 +11,8 @@ s:set("assertion.equals.negative", "Expected objects to not be equal. Passed in:
 s:set("assertion.unique.positive", "Expected object to be unique:\n%s")
 s:set("assertion.unique.negative", "Expected object to not be unique:\n%s")
 
-s:set("assertion.error.positive", "Expected error to be thrown.")
-s:set("assertion.error.negative", "Expected error to not be thrown.\n%s")
+s:set("assertion.error.positive", "Expected a different error. Caught: %s\nExpected: %s")
+s:set("assertion.error.negative", "Expected no error, but caught: %s")
 
 s:set("assertion.truthy.positive", "Expected to be truthy, but value was:\n%s")
 s:set("assertion.truthy.negative", "Expected to not be truthy, but value was:\n%s")


### PR DESCRIPTION
It used to print "Expected error to be thrown." in the case of an error mismatch, which was misleading.
Now it always prints which error was caught and what was expected.
