### PR TITLE
Make assert.has_error work with all kinds of errors

### DIFF
--- a/src/assertions.lua
+++ b/src/assertions.lua
@@ -77,20 +77,16 @@ end
 local function has_error(state, arguments)
   local func = arguments[1]
   local err_expected = arguments[2]
-
   assert(util.callable(func), s("assertion.internal.badargtype", { "error", "function, or callable object", type(func) }))
-  local err_actual = nil
-  --must swap error functions to get the actual error message
-  local old_error = error
-  error = function(err)
-    err_actual = err
-    return old_error(err)
-  end
-  local status = pcall(func)
-  error = old_error
+  local ok, err_actual = pcall(func)
   arguments[1] = err_actual
   arguments[2] = err_expected
-  return not status and (err_expected == nil or same(state, {err_expected, err_actual, ["n"] = 2}))
+  if ok or err_expected == nil then
+    return not ok
+  elseif type(err_actual) == 'string' and type(err_expected) == 'string' then
+    return err_actual:find(err_expected, nil, true) ~= nil
+  end
+  return same(state, {err_expected, err_actual, ["n"] = 2})
 end
 
 local function is_true(state, arguments)


### PR DESCRIPTION
`assert.has_error` used to work by overriding the default `error()` function. Unfortunately this approach doesn't catch errors from `assert()`, internal Lua errors or any error thrown from C, which is very limiting.

This new implementation catches all errors and is almost always backwards compatible. It works exactly as before when the error is not of type string. In the common case when the error _is_ a string, we can no longer make a direct equality comparison because the message will have been changed (augmented with filename/line/column, etc). The solution is to search if the expected message is contained in the actual message. This is more powerful than an equality comparison because it's possible to (optionally) test where the error occurred. It's very unlikely to break tests. And it makes the assertion work with all kinds of errors.
