### PR TITLE
Allow strings to match against error objects in has_error()

### DIFF
--- a/src/assertions.lua
+++ b/src/assertions.lua
@@ -83,8 +83,17 @@ local function has_error(state, arguments)
   arguments[2] = err_expected
   if ok or err_expected == nil then
     return not ok
-  elseif type(err_actual) == 'string' and type(err_expected) == 'string' then
-    return err_actual:find(err_expected, nil, true) ~= nil
+  end
+  if type(err_expected) == 'string' then
+    -- err_actual must be (convertible to) a string
+    local mt = getmetatable(err_actual)
+    if mt and mt.__tostring then
+      err_actual = tostring(err_actual)
+    end
+    if type(err_actual) == 'string' then
+      -- we expect err_expected to be a substring of err_actual
+      return err_actual:find(err_expected, nil, true) ~= nil
+    end
   end
   return same(state, {err_expected, err_actual, ["n"] = 2})
 end


### PR DESCRIPTION
This solves the use case of matching against complex, unpredictable error objects. It's a common idiom in Lua to throw error objects that implement the __tostring metamethod. In many cases it will be more convenient to match against these errors using strings. First, it has the advantage of hiding how the error is implemented. And second, it's the only way to match against error objects that contain unpredictable data (which is common when you decorate your errors with context/system-specific data).

This only affects error objects (i.e. tables) that implement the __tostring metamethod, and it's still possible to match table-against-table if you wish.
