### PR TITLE
Convert error object to string in output_spec

### DIFF
--- a/spec/output_spec.lua
+++ b/spec/output_spec.lua
@@ -1,7 +1,8 @@
 
 local getoutput = function(...)
   local success, message = pcall(assert.are.equal, ...)
-  return message
+  if message == nil then return nil end
+  return tostring(message)
 end
 
 


### PR DESCRIPTION
Update output_spec to convert an error object to string in case it is not already a string. In such a case, the object should be a table with the __tostring metamethod defined, making it convertible to a string.

The assert function does explicitly throw a string, however, the caller can always change the environment such that `error` will instead throw an error object.

For example:

``` lua
local olderror = error
error = function(err)
  local mt = { __index = {}, __tostring = function(e) return e.message end }
  olderror(setmetatable({ message = err }, mt))
end
```
