### PR TITLE
Added missing formatter for threads

### DIFF
--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -74,6 +74,12 @@ local function fmt_userdata(arg)
   end
 end
 
+local function fmt_thread(arg)
+  if type(arg) == "thread" then
+    return string.format("(thread) '%s'", tostring(arg))
+  end
+end
+
 assert:add_formatter(fmt_string)
 assert:add_formatter(fmt_number)
 assert:add_formatter(fmt_boolean)
@@ -81,5 +87,6 @@ assert:add_formatter(fmt_nil)
 assert:add_formatter(fmt_table)
 assert:add_formatter(fmt_function)
 assert:add_formatter(fmt_userdata)
+assert:add_formatter(fmt_thread)
 -- Set default table display depth for table formatter
 assert:set_parameter("TableFormatLevel", 3)


### PR DESCRIPTION
There were formatters for all standard types except for threads (coroutines).
