### PR TITLE
Add missing require in stub.lua

### DIFF
--- a/src/stub.lua
+++ b/src/stub.lua
@@ -1,4 +1,5 @@
 -- module will return a stub module table
+local assert = require 'luassert.assert'
 local spy = require 'luassert.spy'
 local util = require 'luassert.util'
 local stubfunc = function() end
@@ -45,4 +46,4 @@ return setmetatable( stub, {
       -- NOTE: this deviates from spy, which has no __call method
       return stub.new(...)
     end })
-  
+


### PR DESCRIPTION
The following `require` is missing in `stub.lua`
```lua
local assert = require 'luassert.assert'
```
