### PR TITLE
Allow numbers to match against error objects in has_error()

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -241,7 +241,7 @@ describe("Test Assertions", function()
     assert.returned_arguments(3, fn4())
   end)
 
-  it("checks has_error to accept only callable arguments", function()
+  it("Checks has_error to accept only callable arguments", function()
     local t_ok = setmetatable( {}, { __call = function() end } )
     local t_nok = setmetatable( {}, { __call = function() error("some error") end } )
     local f_ok = function() end
@@ -253,6 +253,19 @@ describe("Test Assertions", function()
     assert.has_no_error(t_ok)
   end)
 
-end)
+  it("Checks has_error compares error strings", function()
+    assert.has_error(function() error() end)
+    assert.has_error(function() error("string") end, "string")
+  end)
 
+  it("Checks has_error compares error objects", function()
+    assert.has_error(function() error({ "table" }) end, { "table" })
+  end)
+
+  it("Checks has_error compares error objects with strings", function()
+    local mt = { __tostring = function(t) return t[1] end }
+    assert.has_error(function() error(setmetatable({ "table" }, mt)) end, "table")
+  end)
+
+end)
 

--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -259,7 +259,12 @@ describe("Test Assertions", function()
   end)
 
   it("Checks has_error compares error objects", function()
+    local func = function() end
     assert.has_error(function() error({ "table" }) end, { "table" })
+    assert.has_error(function() error(func) end, func)
+    assert.has_error(function() error(false) end, false)
+    assert.has_error(function() error(true) end, true)
+    assert.has_error(function() error(0) end, 0)
   end)
 
   it("Checks has_error compares error objects with strings", function()

--- a/spec/output_spec.lua
+++ b/spec/output_spec.lua
@@ -1,12 +1,11 @@
 
-local getoutput = function(...)
-  local success, message = pcall(assert.are.equal, ...)
-  if message == nil then return nil end
-  return tostring(message)
-end
-
-
 describe("Output testing using string comparison with the equal assertion", function()
+  local getoutput = function(...)
+    local success, message = pcall(assert.are.equal, ...)
+    if message == nil then return nil end
+    return tostring(message)
+  end
+
   it("Should compare strings correctly; nil-string", function()
     --assert.are.equal(nil, "string")
     local output = getoutput(nil, "string")
@@ -68,6 +67,78 @@ describe("Output testing using string comparison with the equal assertion", func
     assert(ok, "Output check 1 failed, comparing string-nil-string;\n    " .. output:gsub("\n","\n    "))
     local ok = output:find("Expected:\n%(string%) 'string'")
     assert(ok, "Output check 2 failed, comparing string-nil-string;\n    " .. output:gsub("\n","\n    "))
+  end)
+
+end)
+
+describe("Output testing using string comparison with the has_error assertion", function()
+  local getoutput = function(...)
+    local success, message = pcall(assert.has_error, ...)
+    if message == nil then return nil end
+    return tostring(message)
+  end
+
+  it("Should report no error caught, but error expected; noerror-nil", function()
+    --assert.has_error(function() end)
+    local output = getoutput(function() end)
+    local ok = output:find("Caught:\n%(no error%)")
+    assert(ok, "Output check 1 failed, comparing noerror-nil;\n    " .. output:gsub("\n","\n    "))
+    local ok = output:find("Expected:\n%(error%)")
+    assert(ok, "Output check 2 failed, comparing noerror-nil;\n    " .. output:gsub("\n","\n    "))
+  end)
+
+  it("Should report no error caught, but error string expected; noerror-string", function()
+    --assert.has_error(function() end, "string")
+    local output = getoutput(function() end, 'string')
+    local ok = output:find("Caught:\n%(no error%)")
+    assert(ok, "Output check 1 failed, comparing noerror-string;\n    " .. output:gsub("\n","\n    "))
+    local ok = output:find("Expected:\n%(string%) 'string'")
+    assert(ok, "Output check 2 failed, comparing noerror-string;\n    " .. output:gsub("\n","\n    "))
+  end)
+
+  it("Should compare error strings correctly; nil-string", function()
+    --assert.has_error(function() error() end, "string")
+    local output = getoutput(function() error() end, "string")
+    local ok = output:find("Caught:\n%(nil%)")
+    assert(ok, "Output check 1 failed, comparing nil-string;\n    " .. output:gsub("\n","\n    "))
+    local ok = output:find("Expected:\n%(string%) 'string'")
+    assert(ok, "Output check 2 failed, comparing nil-string;\n    " .. output:gsub("\n","\n    "))
+  end)
+
+  it("Should compare error strings correctly; string-string", function()
+    --assert.has_error(function() error("string") end, "string_")
+    local output = getoutput(function() error("string") end, "string_")
+    local ok = output:find("Caught:\n%(string%) '.*: string'")
+    assert(ok, "Output check 1 failed, comparing string-string;\n    " .. output:gsub("\n","\n    "))
+    local ok = output:find("Expected:\n%(string%) 'string_'")
+    assert(ok, "Output check 2 failed, comparing string-string;\n    " .. output:gsub("\n","\n    "))
+  end)
+
+  it("Should compare error strings correctly; table-string", function()
+    --assert.has_error(function() error({}) end, "string")
+    local output = getoutput(function() error({}) end, "string")
+    local ok = output:find("Caught:\n%(table%): { }")
+    assert(ok, "Output check 1 failed, comparing table-string;\n    " .. output:gsub("\n","\n    "))
+    local ok = output:find("Expected:\n%(string%) 'string'")
+    assert(ok, "Output check 2 failed, comparing table-string;\n    " .. output:gsub("\n","\n    "))
+  end)
+
+  it("Should compare error strings correctly; string-table", function()
+    --assert.has_error(function() error("string") end, {})
+    local output = getoutput(function() error("string") end, {})
+    local ok = output:find("Caught:\n%(string%) '.*: string'")
+    assert(ok, "Output check 1 failed, comparing string-table;\n    " .. output:gsub("\n","\n    "))
+    local ok = output:find("Expected:\n%(table%): { }")
+    assert(ok, "Output check 2 failed, comparing string-table;\n    " .. output:gsub("\n","\n    "))
+  end)
+
+  it("Should compare error objects correctly; table-table", function()
+    --assert.has_error(function() error({}) end, { "table" })
+    local output = getoutput(function() error({}) end, { "table" })
+    local ok = output:find("Caught:\n%(table%): { }")
+    assert(ok, "Output check 1 failed, comparing table-table;\n    " .. output:gsub("\n","\n    "))
+    local ok = output:find("Expected:\n%(table%): {\n  %[1] = 'table' }")
+    assert(ok, "Output check 2 failed, comparing table-table;\n    " .. output:gsub("\n","\n    "))
   end)
 
 end)

--- a/src/assertions.lua
+++ b/src/assertions.lua
@@ -99,6 +99,9 @@ local function has_error(state, arguments)
       -- we expect err_expected to be a substring of err_actual
       return err_actual:find(err_expected, nil, true) ~= nil
     end
+  elseif type(err_expected) == 'number' then
+      -- we expect err_expected to be at the end of err_actual
+      return err_actual:match('.*%s+' .. err_expected .. '$') ~= nil
   end
   return same(state, {err_expected, err_actual, ["n"] = 2})
 end


### PR DESCRIPTION
This solves the use case of matching against errors throwing numbers instead of strings or tables. This case is unique because Lua automatically converts the number to a string, which then causes the string comparison to fail against the expected numeric value.
```lua
describe('Test has_error()', function()
  it('compares error with expected error number', function()
    assert.has_error(function() error(0) end, 0)
  end)
end)
```
