### PR TITLE
Use wget in travis setup instead of curl

### DIFF
--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -2,6 +2,8 @@
 # Sets up Lua and Luarocks. 
 # LUA must be "Lua 5.1", "Lua 5.2" or "LuaJIT 2.0". 
 
+set -e
+
 if [ "$LUA" == "LuaJIT 2.0" ]; then
   wget -O - http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
   cd LuaJIT-2.0.2

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -3,22 +3,22 @@
 # LUA must be "Lua 5.1", "Lua 5.2" or "LuaJIT 2.0". 
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then
-  curl http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
+  wget -O - http://luajit.org/download/LuaJIT-2.0.2.tar.gz | tar xz
   cd LuaJIT-2.0.2
   make && sudo make install INSTALL_TSYMNAME=lua;
 else
   if [ "$LUA" == "Lua 5.1" ]; then
-    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    wget -O - http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
     cd lua-5.1.5;
   elif [ "$LUA" == "Lua 5.2" ]; then
-    curl http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
+    wget -O - http://www.lua.org/ftp/lua-5.2.3.tar.gz | tar xz
     cd lua-5.2.3;
   fi
   sudo make linux install;
 fi
 
 cd ..
-curl http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
+wget -O - http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
 cd luarocks-2.1.2
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -18,8 +18,8 @@ else
 fi
 
 cd ..
-wget -O - http://luarocks.org/releases/luarocks-2.1.2.tar.gz | tar xz
-cd luarocks-2.1.2
+wget -O - http://luarocks.org/releases/luarocks-2.2.0.tar.gz | tar xz
+cd luarocks-2.2.0
 
 if [ "$LUA" == "LuaJIT 2.0" ]; then
   ./configure --with-lua-include=/usr/local/include/luajit-2.0;


### PR DESCRIPTION
Switch to using `wget` instead of `curl` in travis setup so that site redirection will work when downloading source packages.

This allows the travis build to work when luarocks.org is down, but being redirected to another site (like it currently is).
