### PR TITLE
Override default stub function

### DIFF
--- a/spec/stub_spec.lua
+++ b/spec/stub_spec.lua
@@ -144,4 +144,54 @@ describe("Tests dealing with stubs", function()
     assert.is.equal("bar", arg3)
   end)
 
+  it("returns default stub arguments", function()
+    stub(test, "key").returns(nil, "foo", "bar")
+
+    local arg1, arg2, arg3 = test.key("bar", nil, "foo")
+
+    assert.is.equal(nil, arg1)
+    assert.is.equal("foo", arg2)
+    assert.is.equal("bar", arg3)
+  end)
+
+  it("invokes default stub function", function()
+    stub(test, "key").invokes(function(a, b, c)
+      return c, b, a
+    end)
+
+    local arg1, arg2, arg3 = test.key("bar", nil, "foo")
+
+    assert.is.equal("foo", arg1)
+    assert.is.equal(nil, arg2)
+    assert.is.equal("bar", arg3)
+  end)
+
+  it("on_call_with returns specified arguments", function()
+    stub(test, "key").returns("foo bar")
+    test.key.on_call_with("bar").returns("foo", nil, "bar")
+
+    local arg1, arg2, arg3 = test.key("bar")
+    local foobar = test.key()
+
+    assert.is.equal("foo", arg1)
+    assert.is.equal(nil, arg2)
+    assert.is.equal("bar", arg3)
+    assert.is.equal("foo bar", foobar)
+  end)
+
+  it("on_call_with invokes stub function", function()
+    stub(test, "key").returns("foo foo")
+    test.key.on_call_with("foo").invokes(function(a, b, c)
+      return "bar", nil, "bar"
+    end)
+
+    local arg1, arg2, arg3 = test.key("foo")
+    local foo = test.key()
+
+    assert.is.equal("bar", arg1)
+    assert.is.equal(nil, arg2)
+    assert.is.equal("bar", arg3)
+    assert.is.equal("foo foo", foo)
+  end)
+
 end)

--- a/spec/stub_spec.lua
+++ b/spec/stub_spec.lua
@@ -166,6 +166,26 @@ describe("Tests dealing with stubs", function()
     assert.is.equal("bar", arg3)
   end)
 
+  it("returns stub arguments by default", function()
+    stub(test, "key").by_default.returns("foo", "bar")
+
+    local arg1, arg2 = test.key()
+
+    assert.is.equal("foo", arg1)
+    assert.is.equal("bar", arg2)
+  end)
+
+  it("invokes stub function by default", function()
+    stub(test, "key").by_default.invokes(function(a, b)
+      return b, a
+    end)
+
+    local arg1, arg2 = test.key("bar", "foo")
+
+    assert.is.equal("foo", arg1)
+    assert.is.equal("bar", arg2)
+  end)
+
   it("on_call_with returns specified arguments", function()
     stub(test, "key").returns("foo bar")
     test.key.on_call_with("bar").returns("foo", nil, "bar")

--- a/spec/stub_spec.lua
+++ b/spec/stub_spec.lua
@@ -101,9 +101,45 @@ describe("Tests dealing with stubs", function()
   it("returns multiple given values", function()
     stub(test, "key", "foo", nil, "bar")
 
-    arg1, arg2, arg3 = test.key()
+    local arg1, arg2, arg3 = test.key()
 
     assert.is.equal("foo", arg1)
+    assert.is.equal(nil, arg2)
+    assert.is.equal("bar", arg3)
+  end)
+
+  it("calls specified stub function", function()
+    stub(test, "key", function(a, b, c)
+      return c, b, a
+    end)
+
+    local arg1, arg2, arg3 = test.key("bar", nil, "foo")
+
+    assert.is.equal("foo", arg1)
+    assert.is.equal(nil, arg2)
+    assert.is.equal("bar", arg3)
+  end)
+
+  it("calls specified stub callable object", function()
+    local callable = setmetatable({}, { __call = function(self, a, b, c)
+      return c, b, a
+    end})
+    stub(test, "key", callable)
+
+    local arg1, arg2, arg3 = test.key("bar", nil, "foo")
+
+    assert.is.equal("foo", arg1)
+    assert.is.equal(nil, arg2)
+    assert.is.equal("bar", arg3)
+  end)
+
+  it("returning multiple given values overrides stub function", function()
+    local function foo() end
+    stub(test, "key", foo, nil, "bar")
+
+    local arg1, arg2, arg3 = test.key()
+
+    assert.is.equal(foo, arg1)
     assert.is.equal(nil, arg2)
     assert.is.equal("bar", arg3)
   end)

--- a/src/spy.lua
+++ b/src/spy.lua
@@ -21,10 +21,10 @@ spy = {
     {
       calls = {},
       callback = callback,
-      
+
       target_table = nil, -- these will be set when using 'spy.on'
       target_key = nil,
-      
+
       revert = function(self)
         if not self.reverted then
           if self.target_table and self.target_key then
@@ -34,7 +34,7 @@ spy = {
         end
         return self.callback
       end,
-      
+
       called = function(self, times, compare)
         if times or compare then
           local compare = compare or function(count, expected) return count == expected end
@@ -60,14 +60,14 @@ spy = {
   is_spy = function(object)
     return type(object) == "table" and getmetatable(object) == spy_mt
   end,
-    
+
   on = function(target_table, target_key)
     local s = spy.new(target_table[target_key])
     target_table[target_key] = s
-    -- store original data 
+    -- store original data
     s.target_table = target_table
     s.target_key = target_key
-    
+
     return s
   end
 }

--- a/src/stub.lua
+++ b/src/stub.lua
@@ -16,7 +16,8 @@ function stub.new(object, key, ...)
   assert(type(object) == "table" and key ~= nil, "stub.new(): Can only create stub on a table key, call with 2 params; table, key")
   assert(object[key] == nil or util.callable(object[key]), "stub.new(): The element for which to create a stub must either be callable, or be nil")
   local old_elem = object[key]    -- keep existing element (might be nil!)
-  local stubfunc = function()
+  local fn = (return_values_count == 1 and util.callable(return_values[1]) and return_values[1])
+  local stubfunc = fn or function()
     return unpack(return_values, 1, return_values_count)
   end
   object[key] = stubfunc          -- set the stubfunction

--- a/src/stub.lua
+++ b/src/stub.lua
@@ -16,14 +16,26 @@ function stub.new(object, key, ...)
   assert(type(object) == "table" and key ~= nil, "stub.new(): Can only create stub on a table key, call with 2 params; table, key")
   assert(object[key] == nil or util.callable(object[key]), "stub.new(): The element for which to create a stub must either be callable, or be nil")
   local old_elem = object[key]    -- keep existing element (might be nil!)
+
   local fn = (return_values_count == 1 and util.callable(return_values[1]) and return_values[1])
-  local stubfunc = fn or function()
+  local defaultfunc = fn or function()
     return unpack(return_values, 1, return_values_count)
   end
+  local stub_call_args = {}
+  local stub_callers = {}
+  local stubfunc = function(...)
+    for _, args in ipairs(stub_call_args) do
+      if util.deepcompare(args, {...}) then
+        return stub_callers[args](...)
+      end
+    end
+    return defaultfunc(...)
+  end
+
   object[key] = stubfunc          -- set the stubfunction
   local s = spy.on(object, key)   -- create a spy on top of the stub function
   local spy_revert = s.revert     -- keep created revert function
-  
+
   s.revert = function(self)       -- wrap revert function to restore original element
     if not self.reverted then
       spy_revert(self)
@@ -32,7 +44,45 @@ function stub.new(object, key, ...)
     end
     return old_elem
   end
-  
+
+  s.returns = function(...)
+    local return_args = {...}
+    local n = select('#', ...)
+    defaultfunc = function()
+      return unpack(return_args, 1, n)
+    end
+    return s
+  end
+
+  s.invokes = function(func)
+    defaultfunc = function(...)
+      return func(...)
+    end
+    return s
+  end
+
+  s.on_call_with = function(...)
+    local match_args = {...}
+    return {
+      returns = function(...)
+        local return_args = {...}
+        local n = select('#', ...)
+        table.insert(stub_call_args, match_args)
+        stub_callers[match_args] = function()
+          return unpack(return_args, 1, n)
+        end
+        return s
+      end,
+      invokes = function(func)
+        table.insert(stub_call_args, match_args)
+        stub_callers[match_args] = function(...)
+          return func(...)
+        end
+        return s
+      end
+    }
+  end
+
   return s
 end
 

--- a/src/stub.lua
+++ b/src/stub.lua
@@ -61,6 +61,11 @@ function stub.new(object, key, ...)
     return s
   end
 
+  s.by_default = {
+    returns = s.returns,
+    invokes = s.invokes,
+  }
+
   s.on_call_with = function(...)
     local match_args = {...}
     return {


### PR DESCRIPTION
This allows the caller to specify a custom stub function to be called instead of using the default stub function to return multiple values.
```lua
local t = { foo = function(msg) return msg end}
stub(t, foo, function(msg)
  if msg == "foo" then return "bar" end
  return nil
end)
print(t.foo("foo")) -- prints "bar"
print(t.foo("bar")) -- prints nil
```
or use the default stub function to return one or more values
```lua
local t = { foo = function(msg) return msg end}
stub(t, foo, "bar")
print(t.foo("foo")) -- prints "bar"
print(t.foo("bar")) -- prints "bar"
```
I believe this would resolve #47.
