### PR TITLE
Fix confusing error messages for `called` asserts

### DIFF
--- a/src/spy.lua
+++ b/src/spy.lua
@@ -85,9 +85,13 @@ end
 
 local function called(state, arguments, compare)
   local num_times = arguments[1]
+  if not num_times and not state.mod then
+    state.mod = true
+    num_times = 0
+  end
   if state.payload and type(state.payload) == "table" and state.payload.called then
     local result, count = state.payload:called(num_times, compare)
-    arguments[1] = tostring(arguments[1])
+    arguments[1] = tostring(num_times or ">0")
     table.insert(arguments, 2, tostring(count))
     arguments.n = arguments.n + 1
     arguments.nofmt = arguments.nofmt or {}


### PR DESCRIPTION
Fixes issue #58 so that the `called` error messages will print either `0` or `>0` instead of `nil` for the expected call count.
```lua
describe("foo", function()
  it("bar", function()
    local func = spy.new(function() end);
    func();
    assert.spy(func).was_not.called();
  end)

  it("bar2", function()
    local func = spy.new(function() end);
    assert.spy(func).was.called();
  end)
end)
```
```
◼◼
0 successes / 2 failures / 0 errors / 0 pending : 0.0 seconds

Failure → foobar_spec.lua @ 2
foo bar
foobar_spec.lua:5: Expected to be called 0 time(s), but was called 1 time(s)

Failure → foobar_spec.lua @ 8
foo bar2
foobar_spec.lua:10: Expected to be called >0 time(s), but was called 0 time(s)
```