### PR TITLE
Add near assertion to compare within tolerance

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -51,6 +51,18 @@ describe("Test Assertions", function()
     assert.is_not.unique(tablenotunique)
   end)
 
+  it("Checks near() assertion handles tolerances", function()
+    assert.is.error(function() assert.near(0) end)  -- minimum 3 arguments
+    assert.is.error(function() assert.near(0, 0) end)  -- minimum 3 arguments
+    assert.is.error(function() assert.near('a', 0, 0) end)  -- arg1 must be convertable to number
+    assert.is.error(function() assert.near(0, 'a', 0) end)  -- arg2 must be convertable to number
+    assert.is.error(function() assert.near(0, 0, 'a') end)  -- arg3 must be convertable to number
+    assert.is.near(1.5, 2.0, 0.5)
+    assert.is.near('1.5', '2.0', '0.5')
+    assert.is_not.near(1.5, 2.0, 0.499)
+    assert.is_not.near('1.5', '2.0', '0.499')
+  end)
+
   it("Ensures the is operator doesn't change the behavior of equals", function()
     assert.is.equals(true, true)
   end)

--- a/src/languages/en.lua
+++ b/src/languages/en.lua
@@ -8,6 +8,9 @@ s:set("assertion.same.negative", "Expected objects to not be the same.\nPassed i
 s:set("assertion.equals.positive", "Expected objects to be equal.\nPassed in:\n%s\nExpected:\n%s")
 s:set("assertion.equals.negative", "Expected objects to not be equal.\nPassed in:\n%s\nDid not expect:\n%s")
 
+s:set("assertion.near.positive", "Expected values to be near.\nPassed in:\n%s\nExpected:\n%s +/- %s")
+s:set("assertion.near.negative", "Expected values to not be near.\nPassed in:\n%s\nDid not expect:\n%s +/- %s")
+
 s:set("assertion.unique.positive", "Expected object to be unique:\n%s")
 s:set("assertion.unique.negative", "Expected object to not be unique:\n%s")
 


### PR DESCRIPTION
This allows the following assertion
```lua
  assert.is_near(expected, actual, tolerance)
```
Fixes issue #62.
