### PR TITLE
Add matches assertion to match strings

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -63,6 +63,20 @@ describe("Test Assertions", function()
     assert.is_not.near('1.5', '2.0', '0.499')
   end)
 
+  it("Checks matches() assertion does string matching", function()
+    assert.is.error(function() assert.matches('.*') end)  -- minimum 2 arguments
+    assert.is.error(function() assert.matches(nil, 's') end)  -- arg1 must be a string
+    assert.is.error(function() assert.matches('s', {}) end)  -- arg2 must be convertable to string
+    assert.is.error(function() assert.matches('s', 's', 's') end)  -- arg3 must be a number or nil
+    assert.matches("%w+", "test")
+    assert.has.match("%w+", "test")
+    assert.has_no.match("%d+", "derp")
+    assert.has.match("test", "test", nil, true)
+    assert.has_no.match("%w+", "test", nil, true)
+    assert.has.match("^test", "123 test", 5)
+    assert.has_no.match("%d+", "123 test", '4')
+  end)
+
   it("Ensures the is operator doesn't change the behavior of equals", function()
     assert.is.equals(true, true)
   end)

--- a/src/assertions.lua
+++ b/src/assertions.lua
@@ -52,6 +52,28 @@ local function near(state, arguments)
   return (actual >= expected - tolerance and actual <= expected + tolerance)
 end
 
+local function matches(state, arguments)
+  local argcnt = arguments.n
+  assert(argcnt > 1, s("assertion.internal.argtolittle", { "same", 2, tostring(argcnt) }))
+  local pattern = arguments[1]
+  local actualtype = type(arguments[2])
+  local actual = nil
+  if actualtype == "string" or actualtype == "number" or
+     actualtype == "table" and (getmetatable(arguments[2]) or {}).__tostring then
+    actual = tostring(arguments[2])
+  end
+  local init = arguments[3]
+  local plain = arguments[4]
+  local stringtype = "string or object convertible to a string"
+  assert(type(pattern) == "string", s("assertion.internal.badargtype", { "matches", "string", type(arguments[1]) }))
+  assert(actual, s("assertion.internal.badargtype", { "matches", stringtype, format(arguments[2]) }))
+  assert(init == nil or tonumber(init), s("assertion.internal.badargtype", { "matches", "number", type(arguments[3]) }))
+  -- switch arguments for proper output message
+  util.tinsert(arguments, 1, actual)
+  util.tremove(arguments, 3)
+  return (actual:find(pattern, init, plain) ~= nil)
+end
+
 local function equals(state, arguments)
   local argcnt = arguments.n
   assert(argcnt > 1, s("assertion.internal.argtolittle", { "equals", 2, tostring(argcnt) }))
@@ -186,6 +208,8 @@ assert:register("assertion", "thread", is_thread, "assertion.same.positive", "as
 assert:register("assertion", "returned_arguments", returned_arguments, "assertion.returned_arguments.positive", "assertion.returned_arguments.negative")
 
 assert:register("assertion", "same", same, "assertion.same.positive", "assertion.same.negative")
+assert:register("assertion", "matches", matches, "assertion.matches.positive", "assertion.matches.negative")
+assert:register("assertion", "match", matches, "assertion.matches.positive", "assertion.matches.negative")
 assert:register("assertion", "near", near, "assertion.near.positive", "assertion.near.negative")
 assert:register("assertion", "equals", equals, "assertion.equals.positive", "assertion.equals.negative")
 assert:register("assertion", "equal", equals, "assertion.equals.positive", "assertion.equals.negative")

--- a/src/languages/en.lua
+++ b/src/languages/en.lua
@@ -11,6 +11,9 @@ s:set("assertion.equals.negative", "Expected objects to not be equal.\nPassed in
 s:set("assertion.near.positive", "Expected values to be near.\nPassed in:\n%s\nExpected:\n%s +/- %s")
 s:set("assertion.near.negative", "Expected values to not be near.\nPassed in:\n%s\nDid not expect:\n%s +/- %s")
 
+s:set("assertion.matches.positive", "Expected strings to match.\nPassed in:\n%s\nExpected:\n%s")
+s:set("assertion.matches.negative", "Expected strings not to match.\nPassed in:\n%s\nDid not expect:\n%s")
+
 s:set("assertion.unique.positive", "Expected object to be unique:\n%s")
 s:set("assertion.unique.negative", "Expected object to not be unique:\n%s")
 


### PR DESCRIPTION
This allows the following assertion:
```lua
assert.has_match(pattern, string [, init [, plain]])
```
similar to `string.find`

Fixes issue #87.
