### PR TITLE
Fix argtoolittle error message for matches

### DIFF
--- a/src/assertions.lua
+++ b/src/assertions.lua
@@ -54,7 +54,7 @@ end
 
 local function matches(state, arguments)
   local argcnt = arguments.n
-  assert(argcnt > 1, s("assertion.internal.argtolittle", { "same", 2, tostring(argcnt) }))
+  assert(argcnt > 1, s("assertion.internal.argtolittle", { "matches", 2, tostring(argcnt) }))
   local pattern = arguments[1]
   local actualtype = type(arguments[2])
   local actual = nil


### PR DESCRIPTION
This fixes the `argtoolittle` error message to display `matches` instead of `same` when printing out the function name.
```
the 'matches' function requires a minimum of 2 arguments, got: 1
```
instead of
```
the 'same' function requires a minimum of 2 arguments, got: 1
```
