### PR TITLE
Fix assert.same giving inconsistent results

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -14,6 +14,16 @@ describe("Test Assertions", function()
     local table1 = { derp = false}
     local table2 = { derp = false}
     assert.same(table1, table2)
+
+    if type(jit) == "table" then
+      loadstring([[
+        local assert = require 'luassert'
+        assert.same(0ULL, 0)
+        assert.same(0, 0ULL)
+        assert.same({0ULL}, {0})
+        assert.same({0}, {0ULL})
+      ]])()
+    end
   end)
   
   it("Checks the same() assertion for tables with protected metatables", function()

--- a/src/util.lua
+++ b/src/util.lua
@@ -2,9 +2,8 @@ local util = {}
 function util.deepcompare(t1,t2,ignore_mt)
   local ty1 = type(t1)
   local ty2 = type(t2)
-  if ty1 ~= ty2 then return false end
   -- non-table types can be directly compared
-  if ty1 ~= 'table' then return t1 == t2 end
+  if ty1 ~= 'table' or ty2 ~= 'table' then return t1 == t2 end
   local mt1 = debug.getmetatable(t1)
   local mt2 = debug.getmetatable(t2)
   -- would equality be determined by metatable __eq?


### PR DESCRIPTION
Remove the type comparison in `util.deepcompare`. This is not needed, instead if either `t1` or `t2` is not a table, then a simple `==` can be used to check for equality. As a result, calling `assert.same(v1, v2)` with non-table elements `v1` and `v2` will yield the same result as calling `assert.same({v1}, {v2})`.

Fixes issue #90
