### PR TITLE
Add returned_with assertion and fix on_call_with

### DIFF
--- a/spec/spies_spec.lua
+++ b/spec/spies_spec.lua
@@ -20,11 +20,33 @@ describe("Tests dealing with spies", function()
     assert.errors(function() assert.spy(test.key).was.called_with("herp") end)
   end)
 
+  it("checks to see if spy keeps track of returned arguments", function()
+    spy.on(test, "key")
+
+    test.key()
+    assert.spy(test.key).was.returned_with("derp")
+    assert.errors(function() assert.spy(test.key).was.returned_with("herp") end)
+  end)
+
   it("checks to see if spy keeps track of number of calls", function()
      spy.on(test, "key")
      test.key()
      test.key("test")
      assert.spy(test.key).was.called(2)
+  end)
+
+  it("checks returned_with() assertions", function()
+    local s = spy.new(function(...) return ... end)
+    local _ = spy._
+
+    s(1, 2, 3)
+    s("a", "b", "c")
+    assert.spy(s).was.returned_with(1, 2, 3)
+    assert.spy(s).was_not.returned_with({1, 2, 3}) -- mind the accolades
+    assert.spy(s).was.returned_with(_, 2, 3) -- matches don't care
+    assert.spy(s).was.returned_with(_, _, _) -- matches multiple don't cares
+    assert.spy(s).was_not.returned_with(_, _, _, _) -- does not match if too many args
+    assert.has_error(function() assert.spy(s).was.returned_with(5, 6) end)
   end)
 
   it("checks called() and called_with() assertions", function()
@@ -86,6 +108,16 @@ describe("Tests dealing with spies", function()
     assert.spy(s).was.called.less_than(3)
     assert.spy(s).was_not.called.less_than(2)
     assert.has_error(function() assert.spy(s).was.called.less_than() end)
+  end)
+
+  it("checkis if called()/called_with assertions fail on non-spies ", function()
+    assert.has_error(assert.was.called)
+    assert.has_error(assert.was.called_at_least)
+    assert.has_error(assert.was.called_at_most)
+    assert.has_error(assert.was.called_more_than)
+    assert.has_error(assert.was.called_less_than)
+    assert.has_error(assert.was.called_with)
+    assert.has_error(assert.was.returned_with)
   end)
 
   it("checks spies to fail when spying on non-callable elements", function()

--- a/spec/stub_spec.lua
+++ b/spec/stub_spec.lua
@@ -8,9 +8,7 @@ describe("Tests dealing with stubs", function()
   end)
   
   it("checks to see if stub keeps track of arguments", function()
-
     stub(test, "key")
-
     test.key("derp")
     assert.stub(test.key).was.called_with("derp")
     assert.errors(function() assert.stub(test.key).was.called_with("herp") end)
@@ -90,6 +88,12 @@ describe("Tests dealing with stubs", function()
      local old_s = s
      s = s:revert()
      assert.is_nil(s)
+  end)
+
+  it("returns nil by default", function()
+    stub(test, "key")
+
+    assert.is_nil(test.key())
   end)
 
   it("returns a given return value", function()
@@ -189,14 +193,21 @@ describe("Tests dealing with stubs", function()
   it("on_call_with returns specified arguments", function()
     stub(test, "key").returns("foo bar")
     test.key.on_call_with("bar").returns("foo", nil, "bar")
+    test.key.on_call_with(stub._, "foo").returns("foofoo")
 
     local arg1, arg2, arg3 = test.key("bar")
+    local foofoo1 = test.key(1, "foo")
+    local foofoo2 = test.key(2, "foo")
+    local foofoo3 = test.key(nil, "foo")
     local foobar = test.key()
 
     assert.is.equal("foo", arg1)
     assert.is.equal(nil, arg2)
     assert.is.equal("bar", arg3)
     assert.is.equal("foo bar", foobar)
+    assert.is.equal("foofoo", foofoo1)
+    assert.is.equal("foofoo", foofoo2)
+    assert.is.equal("foofoo", foofoo3)
   end)
 
   it("on_call_with invokes stub function", function()

--- a/src/languages/en.lua
+++ b/src/languages/en.lua
@@ -44,6 +44,9 @@ s:set("assertion.called_less_than.negative", "Expected not to be called less tha
 s:set("assertion.called_with.positive", "Function was not called with the arguments")
 s:set("assertion.called_with.negative", "Function was called with the arguments")
 
+s:set("assertion.returned_with.positive", "Function was not returned with the arguments")
+s:set("assertion.returned_with.negative", "Function was returned with the arguments")
+
 s:set("assertion.returned_arguments.positive", "Expected to be called with %s argument(s), but was called with %s")
 s:set("assertion.returned_arguments.negative", "Expected not to be called with %s argument(s), but was called with %s")
 

--- a/src/stub.lua
+++ b/src/stub.lua
@@ -2,10 +2,11 @@
 local assert = require 'luassert.assert'
 local spy = require 'luassert.spy'
 local util = require 'luassert.util'
-local stub = {}
 local unpack = require 'luassert.compatibility'.unpack
 
-stub._ = spy._
+local stub = {
+  _ = spy._
+}
 
 function stub.new(object, key, ...)
   if object == nil and key == nil then
@@ -23,13 +24,14 @@ function stub.new(object, key, ...)
   local defaultfunc = fn or function()
     return unpack(return_values, 1, return_values_count)
   end
-  local stub_call_args = {}
-  local stub_callers = {}
+  local oncalls = {}
+  local callbacks = {}
   local stubfunc = function(...)
-    for _, args in ipairs(stub_call_args) do
-      if util.deepcompare(args, {...}) then
-        return stub_callers[args](...)
-      end
+    local args = {...}
+    args.n = select('#', ...)
+    local match = util.matchargs(oncalls, args, stub._)
+    if match then
+      return callbacks[match](...)
     end
     return defaultfunc(...)
   end
@@ -70,19 +72,20 @@ function stub.new(object, key, ...)
 
   s.on_call_with = function(...)
     local match_args = {...}
+    match_args.n = select('#', ...)
     return {
       returns = function(...)
         local return_args = {...}
         local n = select('#', ...)
-        table.insert(stub_call_args, match_args)
-        stub_callers[match_args] = function()
+        table.insert(oncalls, match_args)
+        callbacks[match_args] = function()
           return unpack(return_args, 1, n)
         end
         return s
       end,
       invokes = function(func)
-        table.insert(stub_call_args, match_args)
-        stub_callers[match_args] = function(...)
+        table.insert(oncalls, match_args)
+        callbacks[match_args] = function(...)
           return func(...)
         end
         return s

--- a/src/util.lua
+++ b/src/util.lua
@@ -27,6 +27,35 @@ function util.deepcompare(t1,t2,ignore_mt)
 end
 
 -----------------------------------------------
+-- Finds matching arguments in a saved list of arguments
+-- @param argslist list of arguments from which to search
+-- @param args the arguments of which to find a match
+-- @param dontcare value representing don't care which matches against everything
+-- @return the matching arguments if a match is found, otherwise nil
+function util.matchargs(argslist, args, dontcare)
+  local _ = dontcare == nil and {} or dontcare
+  local function matches(t1, t2)
+    for k1,v1 in pairs(t1) do
+      local v2 = t2[k1]
+      if v1 ~= _ and v2 ~= _ and (v2 == nil or not util.deepcompare(v1,v2)) then
+        return false
+      end
+    end
+    for k2,v2 in pairs(t2) do
+      local v1 = t1[k2]
+      if v1 ~= _ and v2 ~= _ and v1 == nil then return false end
+    end
+    return true
+  end
+  for k,v in ipairs(argslist) do
+    if matches(v, args) then
+      return v
+    end
+  end
+  return nil
+end
+
+-----------------------------------------------
 -- table.insert() replacement that respects nil values.
 -- The function will use table field 'n' as indicator of the
 -- table length, if not set, it will be added.


### PR DESCRIPTION
This adds the `returned_with` assertion for spies.
```lua
local spy.new(function() return 1, 2, 3 end)
s()
assert.spy(s).was.returned_with(1, 2, 3)
```
Also works with don't cares.
```lua
local spy.new(function() return 1, 2, 3 end)
local _ = spy._
s()
assert.spy(s).was.returned_with(1, _, 3)
```
Fix `on_call_with` to match against don't care arguments.
```lua
local test = {}
local _ = stub._
stub(test, "key").on_call_with(_).returns("foo")
assert.is_nil(test.key())
assert.is_nil(test.key(1, 2))
assert.is_equal("foo", test.key(1))
assert.is_equal("foo", test.key(2))
assert.is_equal("foo", test.key('a'))
assert.is_equal("foo", test.key('b'))
assert.is_equal("foo", test.key({}))
```