### PR TITLE
Support for recursive tables

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -45,6 +45,18 @@ describe("Test Assertions", function()
     assert.is_not.same(nil, "a string")
   end)
 
+  it("Checks same() assertion to handle recursive tables", function()
+    local t1 = { k1 = 1, k2 = 2, k3 = t1 }
+    local t2 = { k1 = 1, k2 = 2, k3 = t2 }
+    local t3 = { k1 = 1, k2 = 2, k3 = { k1 = 1, k2 = 2, k3 = t2 } }
+    t1.k3 = t1
+    t2.k3 = t2
+
+    assert.same(t1, t2)
+    assert.same(t1, t3)
+    assert.same(t1, t3)
+  end)
+
   it("Checks to see if tables 1 and 2 are equal", function()
     local table1 = { derp = false}
     local table2 = table1

--- a/spec/spies_spec.lua
+++ b/spec/spies_spec.lua
@@ -80,6 +80,14 @@ describe("Tests dealing with spies", function()
     assert.has_error(function() assert.spy(s).was.called_with(5, 6) end)
   end)
 
+  it("checks called_with(aspy) assertions", function()
+    local s = spy.new(function() end)
+
+    s(s)
+
+    assert.spy(s).was.called_with(s)
+  end)
+
   it("checks called_at_least() assertions", function()
     local s = spy.new(function() end)
 

--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -103,7 +103,12 @@ local function fmt_table(arg, fmtargs)
   local tmax = assert:get_parameter("TableFormatLevel")
   local crumbs = fmtargs and fmtargs.crumbs or {}
 
-  local function ft(t, l)
+  local function ft(t, l, cache)
+    local cache = cache or {}
+    if cache[t] and cache[t] > 0 then
+      return "{ ... recursive }"
+    end
+
     if next(t) == nil then
       return "{ }"
     end
@@ -115,12 +120,14 @@ local function fmt_table(arg, fmtargs)
     local result = "{"
     local keys, nkeys = get_sorted_keys(t)
 
+    cache[t] = (cache[t] or 0) + 1
+
     for i = 1, nkeys do
       local k = keys[i]
       local v = t[k]
 
       if type(v) == "table" then
-        v = ft(v, l + 1)
+        v = ft(v, l + 1, cache)
       elseif type(v) == "string" then
         v = "'"..v.."'"
       end
@@ -130,6 +137,9 @@ local function fmt_table(arg, fmtargs)
       local indent = string.rep(" ",l * 2 - 1)
       result = result .. string.format("\n%s%s[%s] = %s", indent, ch, tostr(k), tostr(v))
     end
+
+    cache[t] = cache[t] - 1
+
     return result .. " }"
   end
 

--- a/src/util.lua
+++ b/src/util.lua
@@ -1,5 +1,5 @@
 local util = {}
-function util.deepcompare(t1,t2,ignore_mt)
+function util.deepcompare(t1,t2,ignore_mt,cache1,cache2)
   local ty1 = type(t1)
   local ty2 = type(t2)
   -- non-table types can be directly compared
@@ -13,12 +13,26 @@ function util.deepcompare(t1,t2,ignore_mt)
   else -- we can skip the deep comparison below if t1 and t2 share identity
     if t1 == t2 then return true end
   end
+
+  -- handle recursive tables
+  local cache1 = cache1 or {}
+  local cache2 = cache2 or {}
+  cache1[t1] = (cache1[t1] or 0)
+  cache2[t2] = (cache2[t2] or 0)
+  if cache1[t1] > 0 and cache2[t2] > 0 then
+    return true
+  end
+
+  cache1[t1] = cache1[t1] + 1
+  cache2[t2] = cache2[t2] + 1
+
   for k1,v1 in pairs(t1) do
     local v2 = t2[k1]
     if v2 == nil then
       return false, {k1}
     end
-    local same, crumbs = util.deepcompare(v1,v2)
+
+    local same, crumbs = util.deepcompare(v1,v2,nil,cache1,cache2)
     if not same then
       crumbs = crumbs or {}
       table.insert(crumbs, k1)
@@ -30,17 +44,27 @@ function util.deepcompare(t1,t2,ignore_mt)
     -- has been done in first loop above
     if t1[k2] == nil then return false, {k2} end
   end
+
+  cache1[t1] = cache1[t1] - 1
+  cache2[t2] = cache2[t2] - 1
+
   return true
 end
 
-function util.deepcopy(t, deepmt)
+function util.deepcopy(t, deepmt, cache)
   if type(t) ~= "table" then return t end
   local copy = {}
+
+  -- handle recursive tables
+  local cache = cache or {}
+  if cache[t] then return cache[t] end
+  cache[t] = copy
+
   for k,v in next, t, nil do
-    copy[k] = util.deepcopy(v)
+    copy[k] = util.deepcopy(v, deepmt, cache)
   end
   if deepmt then
-    debug.setmetatable(copy, util.deepcopy(debug.getmetatable(t)))
+    debug.setmetatable(copy, util.deepcopy(debug.getmetatable(t, nil, cache)))
   else
     debug.setmetatable(copy, debug.getmetatable(t))
   end

--- a/src/util.lua
+++ b/src/util.lua
@@ -52,6 +52,7 @@ function util.deepcompare(t1,t2,ignore_mt,cache1,cache2)
 end
 
 function util.deepcopy(t, deepmt, cache)
+  local spy = require 'luassert.spy'
   if type(t) ~= "table" then return t end
   local copy = {}
 
@@ -61,7 +62,7 @@ function util.deepcopy(t, deepmt, cache)
   cache[t] = copy
 
   for k,v in next, t, nil do
-    copy[k] = util.deepcopy(v, deepmt, cache)
+    copy[k] = (spy.is_spy(v) and v or util.deepcopy(v, deepmt, cache))
   end
   if deepmt then
     debug.setmetatable(copy, util.deepcopy(debug.getmetatable(t, nil, cache)))
@@ -78,8 +79,9 @@ end
 function util.copyargs(args)
   local copy = {}
   local match = require 'luassert.match'
+  local spy = require 'luassert.spy'
   for k,v in pairs(args) do
-    copy[k] = (match.is_matcher(v) and v or util.deepcopy(v))
+    copy[k] = ((match.is_matcher(v) or spy.is_spy(v)) and v or util.deepcopy(v))
   end
   return copy
 end


### PR DESCRIPTION
Adds support for copying and comparing recursive tables, and disables deep copies for spies.
* Allows spies to be passed as arguments to other spies
* Allows comparing tables with recursive references to itself

Fixes issues #54, and olivine-labs/busted#425
