### PR TITLE
Add assert:unregister to remove custom assertions

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -371,5 +371,12 @@ describe("Test Assertions", function()
     assert.has_error(function() assert.no.has.property("name", { name = "jack" }) end)
   end)
 
-end)
+  it("Checks unregister removes assertions", function()
+    assert.has_no_error(function() assert.has_property("name", { name = "jack" }) end)
 
+    assert:unregister("assertion", "has_property")
+
+    assert.has_error(function() assert.has_property("name", { name = "jack" }) end, "luassert: unknown modifier/assertion: 'has_property'")
+  end)
+
+end)

--- a/src/assert.lua
+++ b/src/assert.lua
@@ -78,7 +78,6 @@ obj = {
 
   -- registers a function in namespace
   register = function(self, nspace, name, callback, positive_message, negative_message)
-    -- register
     local lowername = name:lower()
     if not namespace[nspace] then
       namespace[nspace] = {}
@@ -89,6 +88,15 @@ obj = {
       positive_message=positive_message,
       negative_message=negative_message
     }
+  end,
+
+  -- unregisters a function in a namespace
+  unregister = function(self, nspace, name)
+    local lowername = name:lower()
+    if not namespace[nspace] then
+      namespace[nspace] = {}
+    end
+    namespace[nspace][lowername] = nil
   end,
 
   -- registers a formatter


### PR DESCRIPTION
This allows one to remove custom assertions from an assert namespace.
