### PR TITLE
Add table highlight parameters

### DIFF
--- a/spec/formatters_spec.lua
+++ b/spec/formatters_spec.lua
@@ -87,6 +87,14 @@ describe("Test Formatters", function()
     assert.is.equal(expected, formatted)
   end)
 
+  it("Checks to see if self referencing tables can be formatted", function()
+    local t = {1,2}
+    t[3] = t
+    local formatted = assert:format({t, n = 1})[1]
+    local expected = "(table) {\n  [1] = 1\n  [2] = 2\n  [3] = { ... recursive } }"
+    assert.is.equal(expected, formatted)
+  end)
+
   it("Checks to see if table with 0 count is returned empty/0-count", function()
     local t = { ["n"] = 0 }
     local formatted = assert:format(t)

--- a/spec/formatters_spec.lua
+++ b/spec/formatters_spec.lua
@@ -1,5 +1,3 @@
-local assert
-
 local function returnnils()
   -- force the return of nils in an argument array
   local a,b
@@ -8,13 +6,6 @@ end
 
 describe("Test Formatters", function()
   setup(function()
-    -- must reload luassert with _TEST defined to test private elements
-    for k,v in pairs(package.loaded) do 
-      if k:find("luassert") == 1 then package.loaded[k] = false end 
-    end    
-    assert = require("luassert")
-    require('luassert.spy')
-    require('luassert.mock')
   end)
 
   local snapshot

--- a/spec/formatters_spec.lua
+++ b/spec/formatters_spec.lua
@@ -75,6 +75,27 @@ describe("Test Formatters", function()
     assert.is.same(assert:format({ { 1 }, ["n"] = 1 })[1], "(table) { ... more }")
   end)
 
+  it("Checks to see if TableErrorHighlightCharacter changes error character", function()
+    assert:set_parameter("TableErrorHighlightCharacter", "**")
+    local t = {1,2,3}
+    local fmtargs = { {crumbs = {2}} }
+    local formatted = assert:format({t, n = 1, fmtargs = fmtargs})[1]
+    local expected = "(table) {\n  [1] = 1\n**[2] = 2\n  [3] = 3 }"
+    assert.is.equal(expected, formatted)
+  end)
+
+  it("Checks to see if TableErrorHighlightColor changes error color", function()
+    local ok, colors = pcall(require, "term.colors")
+    if not ok then pending("lua term.colors not available") end
+
+    assert:set_parameter("TableErrorHighlightColor", "red")
+    local t = {1,2,3}
+    local fmtargs = { {crumbs = {2}} }
+    local formatted = assert:format({t, n = 1, fmtargs = fmtargs})[1]
+    local expected = string.format("(table) {\n  [1] = 1\n %s[2] = 2\n  [3] = 3 }", colors.red("*"))
+    assert.is.equal(expected, formatted)
+  end)
+
   it("Checks to see if table with 0 count is returned empty/0-count", function()
     local t = { ["n"] = 0 }
     local formatted = assert:format(t)

--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -1,5 +1,21 @@
 -- module will not return anything, only register formatters with the main assert engine
 local assert = require('luassert.assert')
+local ok, term = pcall(require, 'term')
+
+local colors = setmetatable({
+  none = function(c) return c end
+},{ __index = function(self, key)
+  if not ok or not term.isatty(io.stdout) or not term.colors then
+    return function(c) return c end
+  end
+  return function(c)
+    for token in key:gmatch("[^%.]+") do
+      c = term.colors[token](c)
+    end
+    return c
+  end
+end
+})
 
 local function fmt_string(arg)
   if type(arg) == "string" then
@@ -101,7 +117,8 @@ local function fmt_table(arg, fmtargs)
   end
 
   local tmax = assert:get_parameter("TableFormatLevel")
-  local errchar = assert:get_parameter("TableErrorHighlightCharacter")
+  local errchar = assert:get_parameter("TableErrorHighlightCharacter") or ""
+  local errcolor = assert:get_parameter("TableErrorHighlightColor") or "none"
   local crumbs = fmtargs and fmtargs.crumbs or {}
 
   local function ft(t, l, cache)
@@ -134,9 +151,10 @@ local function fmt_table(arg, fmtargs)
       end
 
       local crumb = crumbs[#crumbs - l + 1]
-      local ch = (crumb == k and errchar or " ")
+      local ch = (crumb == k and errchar or "")
       local indent = string.rep(" ",l * 2 - ch:len())
-      result = result .. string.format("\n%s%s[%s] = %s", indent, ch, tostr(k), tostr(v))
+      local mark = (ch:len() == 0 and "" or colors[errcolor](ch))
+      result = result .. string.format("\n%s%s[%s] = %s", indent, mark, tostr(k), tostr(v))
     end
 
     cache[t] = cache[t] - 1
@@ -177,3 +195,4 @@ assert:add_formatter(fmt_thread)
 -- Set default table display depth for table formatter
 assert:set_parameter("TableFormatLevel", 3)
 assert:set_parameter("TableErrorHighlightCharacter", "*")
+assert:set_parameter("TableErrorHighlightColor", "none")

--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -101,6 +101,7 @@ local function fmt_table(arg, fmtargs)
   end
 
   local tmax = assert:get_parameter("TableFormatLevel")
+  local errchar = assert:get_parameter("TableErrorHighlightCharacter")
   local crumbs = fmtargs and fmtargs.crumbs or {}
 
   local function ft(t, l, cache)
@@ -133,8 +134,8 @@ local function fmt_table(arg, fmtargs)
       end
 
       local crumb = crumbs[#crumbs - l + 1]
-      local ch = (crumb == k and "*" or " ")
-      local indent = string.rep(" ",l * 2 - 1)
+      local ch = (crumb == k and errchar or " ")
+      local indent = string.rep(" ",l * 2 - ch:len())
       result = result .. string.format("\n%s%s[%s] = %s", indent, ch, tostr(k), tostr(v))
     end
 
@@ -175,3 +176,4 @@ assert:add_formatter(fmt_userdata)
 assert:add_formatter(fmt_thread)
 -- Set default table display depth for table formatter
 assert:set_parameter("TableFormatLevel", 3)
+assert:set_parameter("TableErrorHighlightCharacter", "*")


### PR DESCRIPTION
This adds parameters to set the table highlight character and color to use when highlighting table differences.
* Color is set using the lua-term colors (i.e. `red`, `red.onblack.bright`, etc.). Use `none` to bypass color formatting.
* The table highlight character can get set to any character or multiple characters (i.e. `*` vs `**`).  The default is `*`.