### PR TITLE
Fix deep compare for recursive tables

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -46,8 +46,8 @@ describe("Test Assertions", function()
   end)
 
   it("Checks same() assertion to handle recursive tables", function()
-    local t1 = { k1 = 1, k2 = 2, k3 = t1 }
-    local t2 = { k1 = 1, k2 = 2, k3 = t2 }
+    local t1 = { k1 = 1, k2 = 2 }
+    local t2 = { k1 = 1, k2 = 2 }
     local t3 = { k1 = 1, k2 = 2, k3 = { k1 = 1, k2 = 2, k3 = t2 } }
     t1.k3 = t1
     t2.k3 = t2
@@ -55,6 +55,87 @@ describe("Test Assertions", function()
     assert.same(t1, t2)
     assert.same(t1, t3)
     assert.same(t1, t3)
+  end)
+
+  it("Checks same() assertion to handle recursive tables that don't match", function()
+    local t1 = {}
+    local t2 = {}
+    local a = {}
+    local b = {}
+    local c = {}
+    local d = {}
+    t1.k1 = a
+    t2.k1 = b
+    a.k1 = c
+    b.k1 = d
+    c.k2 = a
+    d.k2 = d
+    assert.is_table(t1.k1.k1.k2.k1)
+    assert.is_nil(t2.k1.k1.k2.k1)
+    assert.are_not_same(t1, t2)
+  end)
+
+  it("Checks same() assertion to handle recursive tables that don't match - deeper recursion", function()
+    local cycle_root = {}
+    local cycle_1 = {}
+    local cycle_2 = {}
+    cycle_root.k1 = cycle_1
+    cycle_1.k2 = cycle_2
+    cycle_2.k2 = cycle_root
+
+    local mimic_root = {}
+    local mimic_1 = {}
+    local mimic_2 = {}
+    local mimic_3 = {}
+    local self_ref = {}
+    mimic_root.k1 = mimic_1
+    mimic_1.k2 = mimic_2
+    mimic_2.k2 = mimic_3
+    mimic_3.k1 = self_ref
+    self_ref.k2 = self_ref
+
+    assert.is_table(cycle_root.k1.k2.k2.k1.k2.k2.k1)
+    assert.is_nil(mimic_root.k1.k2.k2.k1.k2.k2.k1)
+    assert.are_not_same(cycle_root, mimic_root)
+  end)
+
+  it("Checks same() assertion to handle recursive tables that don't match - multiple recursions", function()
+    local c1, c2, c3, c4 = {}, {}, {}, {}
+    local m1, m2, m3, m4, m5, m6, m7, m8, m9 = {}, {}, {}, {}, {}, {}, {}, {}, {}
+    local r1, r2, r3 = {}, {}, {}
+
+    r1[1] = r3
+    r2[1] = r2
+    r3[1] = r3
+    c2[1] = r2
+    c3[1] = r2
+    c4[1] = r2
+    m2[1] = r3
+    m3[1] = r3
+    m4[1] = r3
+    m6[1] = r3
+    m7[1] = r3
+    m8[1] = r3
+
+    c1[2] = c2
+    c2[3] = c3
+    c3[3] = c4
+    c4[3] = c1
+
+    m1[2] = m2
+    m2[3] = m3
+    m3[3] = m4
+    m4[3] = m5
+    m5[2] = m6
+    m6[3] = m7
+    m7[3] = m8
+    m8[3] = m9
+    m9[2] = r1
+    r1[3] = r1
+
+    assert.is_table(c1[2][3][3][3][2][3][3][3][2][3][3][3][2])
+    assert.is_nil(m1[2][3][3][3][2][3][3][3][2][3][3][3][2])
+    assert.are_not_same(c1, m1)
   end)
 
   it("Checks to see if tables 1 and 2 are equal", function()

--- a/src/util.lua
+++ b/src/util.lua
@@ -1,5 +1,5 @@
 local util = {}
-function util.deepcompare(t1,t2,ignore_mt,cycles,thresh)
+function util.deepcompare(t1,t2,ignore_mt,cycles,thresh1,thresh2)
   local ty1 = type(t1)
   local ty2 = type(t2)
   -- non-table types can be directly compared
@@ -16,14 +16,14 @@ function util.deepcompare(t1,t2,ignore_mt,cycles,thresh)
 
   -- handle recursive tables
   cycles = cycles or {{},{}}
-  thresh = thresh or {1,1}
+  thresh1, thresh2 = (thresh1 or 1), (thresh2 or 1)
   cycles[1][t1] = (cycles[1][t1] or 0)
   cycles[2][t2] = (cycles[2][t2] or 0)
   if cycles[1][t1] == 1 or cycles[2][t2] == 1 then
-    thresh[1] = cycles[1][t1] + 1
-    thresh[2] = cycles[2][t2] + 1
+    thresh1 = cycles[1][t1] + 1
+    thresh2 = cycles[2][t2] + 1
   end
-  if cycles[1][t1] > thresh[1] and cycles[2][t2] > thresh[2] then
+  if cycles[1][t1] > thresh1 and cycles[2][t2] > thresh2 then
     return true
   end
 
@@ -36,7 +36,7 @@ function util.deepcompare(t1,t2,ignore_mt,cycles,thresh)
       return false, {k1}
     end
 
-    local same, crumbs = util.deepcompare(v1,v2,nil,cycles,util.shallowcopy(thresh))
+    local same, crumbs = util.deepcompare(v1,v2,nil,cycles,thresh1,thresh2)
     if not same then
       crumbs = crumbs or {}
       table.insert(crumbs, k1)

--- a/src/util.lua
+++ b/src/util.lua
@@ -1,5 +1,5 @@
 local util = {}
-function util.deepcompare(t1,t2,ignore_mt,cache1,cache2)
+function util.deepcompare(t1,t2,ignore_mt,cycles,thresh)
   local ty1 = type(t1)
   local ty2 = type(t2)
   -- non-table types can be directly compared
@@ -15,16 +15,20 @@ function util.deepcompare(t1,t2,ignore_mt,cache1,cache2)
   end
 
   -- handle recursive tables
-  local cache1 = cache1 or {}
-  local cache2 = cache2 or {}
-  cache1[t1] = (cache1[t1] or 0)
-  cache2[t2] = (cache2[t2] or 0)
-  if cache1[t1] > 0 and cache2[t2] > 0 then
+  cycles = cycles or {{},{}}
+  thresh = thresh or {1,1}
+  cycles[1][t1] = (cycles[1][t1] or 0)
+  cycles[2][t2] = (cycles[2][t2] or 0)
+  if cycles[1][t1] == 1 or cycles[2][t2] == 1 then
+    thresh[1] = cycles[1][t1] + 1
+    thresh[2] = cycles[2][t2] + 1
+  end
+  if cycles[1][t1] > thresh[1] and cycles[2][t2] > thresh[2] then
     return true
   end
 
-  cache1[t1] = cache1[t1] + 1
-  cache2[t2] = cache2[t2] + 1
+  cycles[1][t1] = cycles[1][t1] + 1
+  cycles[2][t2] = cycles[2][t2] + 1
 
   for k1,v1 in pairs(t1) do
     local v2 = t2[k1]
@@ -32,7 +36,7 @@ function util.deepcompare(t1,t2,ignore_mt,cache1,cache2)
       return false, {k1}
     end
 
-    local same, crumbs = util.deepcompare(v1,v2,nil,cache1,cache2)
+    local same, crumbs = util.deepcompare(v1,v2,nil,cycles,util.shallowcopy(thresh))
     if not same then
       crumbs = crumbs or {}
       table.insert(crumbs, k1)
@@ -45,8 +49,8 @@ function util.deepcompare(t1,t2,ignore_mt,cache1,cache2)
     if t1[k2] == nil then return false, {k2} end
   end
 
-  cache1[t1] = cache1[t1] - 1
-  cache2[t2] = cache2[t2] - 1
+  cycles[1][t1] = cycles[1][t1] - 1
+  cycles[2][t2] = cycles[2][t2] - 1
 
   return true
 end


### PR DESCRIPTION
This fixes comparison of recursive tables  The following should now pass:
```lua
local luassert = require "luassert"
local t1 = {}
local t2 = {}
local a = {}
local b = {}
local c = {}
local d = {}
t1.k1 = a
t2.k1 = b
a.k1 = c
b.k1 = d
c.k2 = a
d.k2 = d
luassert.is_table(t1.k1.k1.k2.k1)
luassert.is_nil(t2.k1.k1.k2.k1)
luassert.are_not_same(t1, t2)
```
Thanks @mpeterv for pointing out the failure case.  I think this should cover all cases, but do you think there are any other failure cases?