### PR TITLE
Fix error in building luarocks

### DIFF
--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -32,5 +32,5 @@ else
   ./configure;
 fi
 
-make && sudo make install
+make build && sudo make install
 cd ..


### PR DESCRIPTION
Need to specify `make build` instead of just `make`.  `make` will just output the following without actually building anything
```
- Type 'make build' and 'make install':
  to install to /usr/local as usual.
- Type 'make bootstrap':
  to install LuaRocks in /usr/local as a rock.
```