### PR TITLE
Add table format parameter to show table recursion

### DIFF
--- a/spec/formatters_spec.lua
+++ b/spec/formatters_spec.lua
@@ -90,6 +90,7 @@ describe("Test Formatters", function()
   it("Checks to see if self referencing tables can be formatted", function()
     local t = {1,2}
     t[3] = t
+    assert:set_parameter("TableFormatShowRecursion", true)
     local formatted = assert:format({t, n = 1})[1]
     local expected = "(table) {\n  [1] = 1\n  [2] = 2\n  [3] = { ... recursive } }"
     assert.is.equal(expected, formatted)

--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -117,13 +117,14 @@ local function fmt_table(arg, fmtargs)
   end
 
   local tmax = assert:get_parameter("TableFormatLevel")
+  local showrec = assert:get_parameter("TableFormatShowRecursion")
   local errchar = assert:get_parameter("TableErrorHighlightCharacter") or ""
   local errcolor = assert:get_parameter("TableErrorHighlightColor") or "none"
   local crumbs = fmtargs and fmtargs.crumbs or {}
 
   local function ft(t, l, cache)
     local cache = cache or {}
-    if cache[t] and cache[t] > 0 then
+    if showrec and cache[t] and cache[t] > 0 then
       return "{ ... recursive }"
     end
 
@@ -194,5 +195,6 @@ assert:add_formatter(fmt_userdata)
 assert:add_formatter(fmt_thread)
 -- Set default table display depth for table formatter
 assert:set_parameter("TableFormatLevel", 3)
+assert:set_parameter("TableFormatShowRecursion", false)
 assert:set_parameter("TableErrorHighlightCharacter", "*")
 assert:set_parameter("TableErrorHighlightColor", "none")


### PR DESCRIPTION
This adds the `TableFormatShowRecursion` parameter to enable showing of table recursion when a table is formatted for display.  This parameter is set to `false` by default.
```lua
  it("Test recursive table - show recursion", function()
    local t = {1,2}
    t[3] = t
    assert:set_parameter("TableFormatShowRecursion", true)
    assert.is.equal({}, t)
  end)
```
```
Failure → spec/test_spec.lua @ 1
Test recursive table - show recursion
spec/test_spec.lua:5: Expected objects to be equal.
Passed in:
(table) {
  [1] = 1
  [2] = 2
  [3] = { ... recursive } }
Expected:
(table) { }
```
vs
```lua
  it("Test recursive table - no show recursion", function()
    local t = {1,2}
    t[3] = t
    assert:set_parameter("TableFormatShowRecursion", false)  -- this is the default value
    assert.is.equal({}, t)
  end)
```
```
Failure → spec/test_spec.lua @ 1
Test recursive table - no show recursion
spec/test_spec.lua:5: Expected objects to be equal.
Passed in:
(table) {
  [1] = 1
  [2] = 2
  [3] = {
    [1] = 1
    [2] = 2
    [3] = {
      [1] = 1
      [2] = 2
      [3] = { ... more } } } }
Expected:
(table) { }
```