### PR TITLE
Fix TableFormatLevel to display all levels

### DIFF
--- a/spec/formatters_spec.lua
+++ b/spec/formatters_spec.lua
@@ -66,6 +66,15 @@ describe("Test Formatters", function()
     assert.is.same(assert:format({ { 1 }, ["n"] = 1 })[1], "(table) { ... more }")
   end)
 
+  it("Checks to see if TableFormatLevel parameter can display all levels", function()
+    assert:set_parameter("TableFormatLevel", -1)
+    assert.is.same(assert:format({ { { { { 1 } } } }, ["n"] = 1 })[1], [[(table) {
+  [1] = {
+    [1] = {
+      [1] = {
+        [1] = 1 } } } }]])
+  end)
+
   it("Checks to see if TableErrorHighlightCharacter changes error character", function()
     assert:set_parameter("TableErrorHighlightCharacter", "**")
     local t = {1,2,3}

--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -131,7 +131,7 @@ local function fmt_table(arg, fmtargs)
       return "{ }"
     end
 
-    if l > tmax then
+    if l > tmax and tmax >= 0 then
       return "{ ... more }"
     end
 


### PR DESCRIPTION
This displays all table levels when `TableFormatLevel` is set to -1, or any value less than 0.