### PR TITLE
Fixes for using luassert with debugger

### DIFF
--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -5,7 +5,8 @@ local ok, term = pcall(require, 'term')
 local colors = setmetatable({
   none = function(c) return c end
 },{ __index = function(self, key)
-  if not ok or not term.isatty(io.stdout) or not term.colors then
+  local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
+  if not ok or not isatty or not term.colors then
     return function(c) return c end
   end
   return function(c)


### PR DESCRIPTION
When debugging with a remote debugger, `io.stdout` is not a file, but a table. This causes `isatty` to fail. Hence, before calling `isatty`, make sure `io.stdout` is a file.
