### PR TITLE
Fix TTY detection

### DIFF
--- a/src/formatters/init.lua
+++ b/src/formatters/init.lua
@@ -1,11 +1,11 @@
 -- module will not return anything, only register formatters with the main assert engine
 local assert = require('luassert.assert')
-local ok, term = pcall(require, 'term')
 
 local colors = setmetatable({
   none = function(c) return c end
 },{ __index = function(self, key)
-  local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
+  local ok, term = pcall(require, 'term')
+  local isatty = io.type(io.stdout) == 'file' and ok and term.isatty(io.stdout)
   if not ok or not isatty or not term.colors then
     return function(c) return c end
   end


### PR DESCRIPTION
This fixes an error in the way `term.isatty` is called. If the `term` module is not present, then `term.isatty` will trigger an error. So we have to make sure that the call to `require 'term'` succeeded before using `term`.