### PR TITLE
Allow asserts to be passed to functions

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -1,3 +1,5 @@
+local tablex = require 'pl.tablex'
+
 describe("Test Assertions", function()
   it("Tests backward compatible assert() functionality", function()
     local test = true
@@ -8,6 +10,13 @@ describe("Test Assertions", function()
     assert(one == test and two == message and three == third_arg and
            four == fourth_arg and five == nil,
            "Expected input values to be outputted as well when an assertion does not fail")
+  end)
+
+  it("Checks asserts can be reused", function()
+    local is_same = assert.is_same
+    local orig_same = tablex.deepcopy(is_same)
+    is_same({}, {})
+    assert.is_same(orig_same, is_same)
   end)
 
   it("Checks to see if tables 1 and 2 are the same", function()
@@ -551,5 +560,4 @@ describe("Test Assertions", function()
     assert.is_same({nil, "string"}, {assert.no_error_matches(function() end, "string")})
     assert.is_same({"error", "string"}, {assert.no_error_matches(function() error("error") end, "string")})
   end)
-
 end)

--- a/src/assert.lua
+++ b/src/assert.lua
@@ -24,7 +24,6 @@ local __state_meta = {
 
   __call = function(self, ...)
     local keys = util.extract_keys("assertion", self.tokens)
-    self.tokens = {}
 
     local assertion
 
@@ -59,6 +58,7 @@ local __state_meta = {
     else
       local arguments = {...}
       arguments.n = select('#', ...)
+      self.tokens = {}
 
       for _, key in ipairs(keys) do
         if namespace.modifier[key] then


### PR DESCRIPTION
This allows assert functions to be passed as arguments and called multiple times using the same table instance.

For example:
```lua
describe('Test using asserts passed to function', function()
  local function check_values(check, value, t)
    for _,v in ipairs(t) do
      check(value, v)
    end
  end

  it('check values in table', function()
    check_values(assert.is_equal, 5, {5, 5, 5})
    check_values(assert.is_not_equal, 0, {1, 2, 3})
  end)
end)
```