### PR TITLE
fix(assert) prevent assert() to crash when level is given

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -12,6 +12,15 @@ describe("Test Assertions", function()
            "Expected input values to be outputted as well when an assertion does not fail")
   end)
 
+  it("Checks assert() handles more than two return values", function()
+    local res, err = pcall(assert, false, "some error", "a string")
+    assert(not res)
+
+    err = tostring(err)
+    assert(not err:match("attempt to perform arithmetic on a string value", nil, true))
+    assert(err:match("some error", nil, true))
+  end)
+
   it("Checks asserts can be reused", function()
     local is_same = assert.is_same
     local orig_same = tablex.deepcopy(is_same)

--- a/src/assert.lua
+++ b/src/assert.lua
@@ -134,15 +134,15 @@ obj = {
   set_parameter = function(self, name, value)
     astate.set_parameter(name, value)
   end,
-  
+
   get_parameter = function(self, name)
     return astate.get_parameter(name)
-  end,  
-  
+  end,
+
   add_spy = function(self, spy)
     astate.add_spy(spy)
   end,
-  
+
   snapshot = function(self)
     return astate.snapshot()
   end,
@@ -152,8 +152,11 @@ local __meta = {
 
   __call = function(self, bool, message, level, ...)
     if not bool then
-      local level = (level or 1) + 1
-      error(message or "assertion failed!", level)
+      local lvl = 2
+      if type(level) == "number" then
+        lvl = level + 1
+      end
+      error(message or "assertion failed!", lvl)
     end
     return bool , message , level , ...
   end,


### PR DESCRIPTION
When commonly using the Lua idiom:

```
local result = assert(some_method())
```

in tests written with busted, it happens that `some_method()` might
return more than 2 values: a boolean, a string and something else.
However, if the assertion fails because ret #1 is falsy, and if ret #3
is not a number, the actual error (ret #2) would be supersed with:

```
luassert/assert.lua:155: attempt to perform arithmetic on a string value
```

This can be annoying to debug (temporarily remove the ret #3 value from
`some_method()` or caching the return values before calling `assert()`) just
in order to see what the actual error is.

This proposes to check that `level` is a number before trying to perform
arithmetic on it, and provide another variable with a default of 2 in
case not. The only drawback is that if ret #3 already is a number, we
might get a wrong level. That is probably less likely than the above
happening, it has been quite common in our tests.
