### PR TITLE
fixes assertion level parameter

### DIFF
--- a/spec/assertions_spec.lua
+++ b/spec/assertions_spec.lua
@@ -11,7 +11,23 @@ describe("Test Assertions", function()
            four == fourth_arg and five == nil,
            "Expected input values to be outputted as well when an assertion does not fail")
   end)
+  
+  it("Checks assert() handles more than two return values", function()
+    local res, err = pcall(assert, false, "some error", "a string")
+    assert(not res)
 
+    err = tostring(err)
+    assert(not err:match("attempt to perform arithmetic on a string value", nil, true))
+    assert(err:match("some error", nil, true))
+  end)
+
+  it("Checks level and get_level values", function()
+    assert.equal(3, assert:get_level(assert:level(3)))
+    assert.is.Nil(assert:get_level({}))
+    assert.is.Nil(assert:get_level("hello world"))
+    assert.is.Nil(assert:get_level(nil))
+  end)
+  
   it("Checks asserts can be reused", function()
     local is_same = assert.is_same
     local orig_same = tablex.deepcopy(is_same)

--- a/src/assert.lua
+++ b/src/assert.lua
@@ -150,7 +150,7 @@ obj = {
   
   level = function(self, level)
     return setmetatable({
-        level
+        level = level
       }, level_mt)
   end,
   
@@ -168,7 +168,7 @@ local __meta = {
   __call = function(self, bool, message, level, ...)
     if not bool then
       local err_level = (self:get_level(level) or 1) + 1
-      error((message or "assertion failed!")..tostring(err_level), err_level)
+      error(message or "assertion failed!", err_level)
     end
     return bool , message , level , ...
   end,


### PR DESCRIPTION
improved version of #141

This will only use the level parameter as a level if it was created using `assert:level(xyz)`
