### PR TITLE
Added missing French translation

### DIFF
--- a/src/languages/fr.lua
+++ b/src/languages/fr.lua
@@ -1,21 +1,50 @@
 local s = require('say')
 
-s:set_namespace("fr")
+s:set_namespace('fr')
 
-s:set("assertion.same.positive", "Objets supposes de meme nature attendus.\nArgument passe:\n%s\nAttendu:\n%s")
-s:set("assertion.same.negative", "Objets supposes de natures differentes attendus.\nArgument passe:\n%s\nNon attendu:\n%s")
+s:set("assertion.called.positive", "Prévu pour être appelé %s fois(s), mais a été appelé %s fois(s).")
+s:set("assertion.called.negative", "Prévu de ne pas être appelé exactement %s fois(s), mais ceci a été le cas.")
 
-s:set("assertion.equals.positive", "Objets supposes etre de valeur egale attendus.\nArgument passe:\n%s\nAttendu:\n%s")
-s:set("assertion.equals.negative", "Objets supposes etre de valeurs differentes attendu.\nArgument passe:\n%s\nNon attendu:\n%s")
+s:set("assertion.called_at_least.positive", "Prévu pour être appelé au moins %s fois(s), mais a été appelé %s fois(s).")
+s:set("assertion.called_at_most.positive", "Prévu pour être appelé au plus %s fois(s), mais a été appelé %s fois(s).")
 
-s:set("assertion.unique.positive", "Objet suppose etre unique attendu:\n%s")
-s:set("assertion.unique.negative", "Objet suppose ne pas etre unique attendu:\n%s")
+s:set("assertion.called_more_than.positive", "Devrait être appelé plus de %s fois(s), mais a été appelé %s fois(s).")
+s:set("assertion.called_less_than.positive", "Devrait être appelé moins de %s fois(s), mais a été appelé %s fois(s).")
 
-s:set("assertion.error.positive", "Erreur supposee etre generee.")
-s:set("assertion.error.negative", "Erreur non supposee etre generee.\n%s")
+s:set("assertion.called_with.positive", "La fonction n'a pas été appelée avec les arguments.")
+s:set("assertion.called_with.negative", "La fonction a été appelée avec les arguments.")
 
-s:set("assertion.truthy.positive", "Assertion supposee etre vraie mais de valeur:\n%s")
-s:set("assertion.truthy.negative", "Assertion supposee etre fausse mais de valeur:\n%s")
+s:set("assertion.equals.positive", "Les objets attendus doivent être égaux. \n Argument passé en: \n %s \n Attendu: \n %s.")
+s:set("assertion.equals.negative", "Les objets attendus ne doivent pas être égaux. \n Argument passé en: \n %s \n Non attendu: \n %s.")
 
-s:set("assertion.falsy.positive", "Assertion supposee etre fausse mais de valeur:\n%s")
-s:set("assertion.falsy.negative", "Assertion supposee etre vraie mais de valeur:\n%s")
+s:set("assertion.error.positive", "Une erreur différente est attendue. \n Prise: \n %s \n Attendue: \n %s.")
+s:set("assertion.error.negative", "Aucune erreur attendue, mais prise: \n %s.")
+
+s:set("assertion.falsy.positive", "Assertion supposée etre fausse mais de valeur: \n %s")
+s:set("assertion.falsy.negative", "Assertion supposée etre vraie mais de valeur: \n %s")
+
+-- errors
+s:set("assertion.internal.argtolittle", "La fonction '%s' requiert un minimum de %s arguments, obtenu: %s.")
+s:set("assertion.internal.badargtype", "Mauvais argument #%s pour '%s' (%s attendu, obtenu %s).")
+-- errors
+
+s:set("assertion.matches.positive", "Chaînes attendues pour correspondre. \n Argument passé en: \n %s \n Attendu: \n %s.")
+s:set("assertion.matches.negative", "Les chaînes attendues ne doivent pas correspondre. \n Argument passé en: \n %s \n Non attendu: \n %s.")
+
+s:set("assertion.near.positive", "Les valeurs attendues sont proches. \n Argument passé en: \n %s \n Attendu: \n %s +/- %s.")
+s:set("assertion.near.negative", "Les valeurs attendues ne doivent pas être proches. \n Argument passé en: \n %s \n Non attendu: \n %s +/- %s.")
+
+s:set("assertion.returned_arguments.positive", "Attendu pour être appelé avec le(s) argument(s) %s, mais a été appelé avec %s.")
+s:set("assertion.returned_arguments.negative", "Attendu pour ne pas être appelé avec le(s) argument(s) %s, mais a été appelé avec %s.")
+
+s:set("assertion.returned_with.positive", "La fonction n'a pas été retournée avec les arguments.")
+s:set("assertion.returned_with.negative", "La fonction a été retournée avec les arguments.")
+
+s:set("assertion.same.positive", "Les objets attendus sont les mêmes. \n Argument passé en: \n %s \n Attendu: \n %s.")
+s:set("assertion.same.negative", "Les objets attendus ne doivent pas être les mêmes. \n Argument passé en: \n %s \n Non attendu: \n %s.")
+
+s:set("assertion.truthy.positive", "Assertion supposee etre vraie mais de valeur: \n %s")
+s:set("assertion.truthy.negative", "Assertion supposee etre fausse mais de valeur: \n %s")
+
+s:set("assertion.unique.positive", "Objet attendu pour être unique: \n %s.")
+s:set("assertion.unique.negative", "Objet attendu pour ne pas être unique: \n %s.")


### PR DESCRIPTION
I wanted to clarify the structure of the code to facilitate my translation.

- Including arranging in alphabetical order
- Then separate by spaces (\n, %s).
- Also between called_at_least and called_less_than.
- Add dots at the end of the strings.
- Put the two capital letters in --errors