### PR TITLE
Add default value to Spy constructor argument

### DIFF
--- a/spec/spies_spec.lua
+++ b/spec/spies_spec.lua
@@ -217,4 +217,10 @@ describe("Tests dealing with spies", function()
      assert.spy(s).was_not.returned_with("foobar")
   end)
 
+  it("checks spy.new can be constructed without arguments", function()
+    local s = spy.new()
+    s()
+    assert.spy(s).was.called(1)
+  end)
+
 end)

--- a/src/spy.lua
+++ b/src/spy.lua
@@ -21,6 +21,7 @@ local spy_mt = {
 local spy   -- must make local before defining table, because table contents refers to the table (recursion)
 spy = {
   new = function(callback)
+    callback = callback or function() end
     if not util.callable(callback) then
       error("Cannot spy on type '" .. type(callback) .. "', only on functions or callable elements", util.errorlevel())
     end


### PR DESCRIPTION
This allows replacing

```lua
mySpy = spy.new(function() end)
```

with

```lua
mySpy = spy.new()
```