### PR TITLE
Better spy assertion messages

### DIFF
--- a/src/languages/en.lua
+++ b/src/languages/en.lua
@@ -37,8 +37,8 @@ s:set("assertion.called_less_than.positive", "Expected to be called less than %s
 s:set("assertion.called_with.positive", "Function was never called with the arguments")
 s:set("assertion.called_with.negative", "Function was called with the arguments at least once")
 
-s:set("assertion.returned_with.positive", "Function was not returned with the arguments")
-s:set("assertion.returned_with.negative", "Function was returned with the arguments")
+s:set("assertion.returned_with.positive", "Function never returned the arguments")
+s:set("assertion.returned_with.negative", "Function returned the arguments at least once")
 
 s:set("assertion.returned_arguments.positive", "Expected to be called with %s argument(s), but was called with %s")
 s:set("assertion.returned_arguments.negative", "Expected not to be called with %s argument(s), but was called with %s")

--- a/src/languages/en.lua
+++ b/src/languages/en.lua
@@ -34,8 +34,8 @@ s:set("assertion.called_at_most.positive", "Expected to be called at most %s tim
 s:set("assertion.called_more_than.positive", "Expected to be called more than %s time(s), but was called %s time(s)")
 s:set("assertion.called_less_than.positive", "Expected to be called less than %s time(s), but was called %s time(s)")
 
-s:set("assertion.called_with.positive", "Function was not called with the arguments")
-s:set("assertion.called_with.negative", "Function was called with the arguments")
+s:set("assertion.called_with.positive", "Function was never called with the arguments")
+s:set("assertion.called_with.negative", "Function was called with the arguments at least once")
 
 s:set("assertion.returned_with.positive", "Function was not returned with the arguments")
 s:set("assertion.returned_with.negative", "Function was returned with the arguments")


### PR DESCRIPTION
Until issue #155 can be addressed it would be helpful if the messages for failed assertions on called_with and returned_with gave some clue as to why no more information is output.