### PR TITLE
Allow spy.on with tables that error on __newindex

### DIFF
--- a/src/spy.lua
+++ b/src/spy.lua
@@ -90,7 +90,7 @@ spy = {
 
   on = function(target_table, target_key)
     local s = spy.new(target_table[target_key])
-    target_table[target_key] = s
+    rawset(target_table, target_key, s)
     -- store original data
     s.target_table = target_table
     s.target_key = target_key


### PR DESCRIPTION
Allows using spy with tables that error on __newindex.

For example:
```
local MyCls = {}
function MyCls:foo() end
function MyCls:__newindex() error("No new indexes for you!") end

myinstance = setmetatable({}, MyCls)

local myspy = spy.on(myinstance, "foo")
myinstance:foo()
assert.spy(myinstance.foo).was.called(1)
```

Would fail on `local myspy = spy.on(myinstance, "foo")` because of error `No new indexes for you!`.
With `rawset` it succeeds because `__newindex` is never called.

This might affect some use cases where it is expected that `__newindex` is called, any ideas and is this acceptable approach?