### PR TITLE
Add Dependabot for GitHub Actions and pin workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    cooldown:  # https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
+      default-days: 7

--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: luarocks/gh-actions-lua@master
+      - uses: luarocks/gh-actions-lua@fc6f8de246f8c01f6e1a56a1b851143e23370ff3 # master
         with:
           luaVersion: ${{ matrix.luaVersion }}
 
-      - uses: luarocks/gh-actions-luarocks@master
+      - uses: luarocks/gh-actions-luarocks@95d2308a0aff36ad31ebadca493ed14853399842 # master
         with:
           luaRocksVersion: "3.13.0"
 

--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - uses: luarocks/gh-actions-lua@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,12 +5,12 @@ on: [ push, workflow_dispatch ]
 jobs:
 
   affected:
-    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@main
+    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
 
   build:
     needs: affected
     if: ${{ needs.affected.outputs.rockspecs }}
-    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@main
+    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
 
@@ -27,7 +27,7 @@ jobs:
         ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') ) &&
         needs.affected.outputs.rockspecs
       }}
-    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@main
+    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@5e21af2b298be5ad6677a4737114db239510d3ce # main
     with:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
     secrets:

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@2445a9dd3859655646bd6eb848459f2b46b4a3e3 # v0


### PR DESCRIPTION
This PR adds Dependabot support for GitHub Actions and pins workflow action references to commit SHAs.

Commits:
1. Add Dependabot config for GitHub Actions (modeled after terminal.lua)
2. Pin workflow actions to commit SHAs and include version/tag comments after each SHA so Dependabot can update both.